### PR TITLE
Add storage layer using Cloud Datastore

### DIFF
--- a/drac/drac.go
+++ b/drac/drac.go
@@ -11,6 +11,8 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/m-lab/go/warnonerror"
+
 	"golang.org/x/crypto/ssh"
 )
 
@@ -178,7 +180,7 @@ func (c *Connection) Exec(cmd string) (string, error) {
 		log.Printf("Error while initializing session: %s", err)
 		return "", err
 	}
-	defer c.close()
+	defer warnonerror.Close(c.session, "Warning: ignoring error")
 
 	out, err := c.session.CombinedOutput(cmd)
 	if err != nil {

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -1,3 +1,5 @@
+// Package storage contains types and functions to retrieve data from Google
+// Cloud Datastore.
 package storage
 
 import (
@@ -21,8 +23,8 @@ type Credentials struct {
 	Address  string `datastore:"address"`
 }
 
-// FindCredentials retrieves a username/password pair from Google Cloud
-// Datastore for a given hostname.
+// FindCredentials retrieves a username/password pair from a DatastoreClient
+// for a given hostname.
 func FindCredentials(ctx context.Context, dc iface.DatastoreClient,
 	host string) (*Credentials, error) {
 

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -1,0 +1,44 @@
+package storage
+
+import (
+	"context"
+
+	"cloud.google.com/go/datastore"
+	"github.com/m-lab/reboot-service/storage/iface"
+)
+
+const datastoreKind = "Credentials"
+
+// Credentials is a struct holding the credentials for a given hostname,
+// plus some additional metadata such as the IP address and the model (DRAC
+// or otherwise).
+type Credentials struct {
+	Hostname string `datastore:"hostname"`
+	Username string `datastore:"username"`
+	Password string `datastore:"password"`
+	Model    string `datastore:"model"`
+	Address  string `datastore:"address"`
+}
+
+// FindCredentials retrieves a username/password pair from Google Cloud
+// Datastore for a given hostname.
+func FindCredentials(ctx context.Context, dc iface.DatastoreClient,
+	host string) (*Credentials, error) {
+
+	query := datastore.NewQuery(datastoreKind)
+	query = query.Filter("hostname = ", host)
+
+	var creds []*Credentials
+	_, err := dc.GetAll(ctx, query, &creds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(creds) == 0 {
+		return nil, err
+	}
+
+	cred := creds[0]
+	return cred, nil
+}

--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 
 	"cloud.google.com/go/datastore"
 	"github.com/m-lab/reboot-service/storage/iface"
@@ -36,7 +37,7 @@ func FindCredentials(ctx context.Context, dc iface.DatastoreClient,
 	}
 
 	if len(creds) == 0 {
-		return nil, err
+		return nil, errors.New("Hostname not found in Datastore")
 	}
 
 	cred := creds[0]

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -8,14 +8,14 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
-// MockDatastoreClient is a fake DatastoreClient for testing.
-type MockDatastoreClient struct {
+// mockDatastoreClient is a fake DatastoreClient for testing.
+type mockDatastoreClient struct {
 	Creds      []*Credentials
 	mustFail   bool
 	skipAppend bool
 }
 
-func (d MockDatastoreClient) GetAll(ctx context.Context, q *datastore.Query,
+func (d mockDatastoreClient) GetAll(ctx context.Context, q *datastore.Query,
 	dst interface{}) ([]*datastore.Key, error) {
 
 	if d.mustFail {
@@ -48,7 +48,7 @@ var fakeDrac = &Credentials{
 
 func TestFindCredentials(t *testing.T) {
 	ctx := context.Background()
-	var mockClient = MockDatastoreClient{
+	var mockClient = mockDatastoreClient{
 		Creds: []*Credentials{
 			fakeDrac,
 		},

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -1,0 +1,54 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/datastore"
+)
+
+type DatastoreClientMock struct {
+	Creds []*Credentials
+}
+
+func (DatastoreClientMock) GetAll(ctx context.Context, q *datastore.Query,
+	dst interface{}) ([]*datastore.Key, error) {
+
+	creds := dst.(*[]*Credentials)
+	*creds = append(*creds, fakeDrac)
+	return nil, nil
+}
+
+const (
+	testHost    = "test"
+	testUser    = "user"
+	testPass    = "pass"
+	testModel   = "drac"
+	testAddress = "addr"
+)
+
+var fakeDrac = &Credentials{
+	Hostname: testHost,
+	Username: testUser,
+	Password: testPass,
+	Model:    testModel,
+	Address:  testAddress,
+}
+
+var mockClient = DatastoreClientMock{
+	Creds: []*Credentials{
+		fakeDrac,
+	},
+}
+
+func TestFindCredentials(t *testing.T) {
+	creds, err := FindCredentials(context.Background(), mockClient, testHost)
+	if err != nil {
+		t.Errorf("FindCredentials() error = %v", err)
+		return
+	}
+
+	if creds.Hostname != fakeDrac.Hostname || creds.Username != fakeDrac.Username || creds.Password != fakeDrac.Password {
+		t.Errorf("FindCredentials() didn't return a valid Credentials")
+	}
+}

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -60,7 +60,7 @@ func TestFindCredentials(t *testing.T) {
 		return
 	}
 
-	if creds.Hostname != fakeDrac.Hostname || creds.Username != fakeDrac.Username || creds.Password != fakeDrac.Password {
+	if *creds != *fakeDrac {
 		t.Errorf("FindCredentials() didn't return a valid Credentials.")
 	}
 

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -8,14 +8,14 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
-// DatastoreClientMock is a fake DatastoreClient for testing.
-type DatastoreClientMock struct {
+// MockDatastoreClient is a fake DatastoreClient for testing.
+type MockDatastoreClient struct {
 	Creds      []*Credentials
 	mustFail   bool
 	skipAppend bool
 }
 
-func (d DatastoreClientMock) GetAll(ctx context.Context, q *datastore.Query,
+func (d MockDatastoreClient) GetAll(ctx context.Context, q *datastore.Query,
 	dst interface{}) ([]*datastore.Key, error) {
 
 	if d.mustFail {
@@ -46,37 +46,37 @@ var fakeDrac = &Credentials{
 	Address:  testAddress,
 }
 
-var mockClient = DatastoreClientMock{
-	Creds: []*Credentials{
-		fakeDrac,
-	},
-}
-
 func TestFindCredentials(t *testing.T) {
 	ctx := context.Background()
+	var mockClient = MockDatastoreClient{
+		Creds: []*Credentials{
+			fakeDrac,
+		},
+	}
 
+	// FindCredentials must return valid credentials for a known hostname.
 	creds, err := FindCredentials(ctx, mockClient, testHost)
 	if err != nil {
 		t.Errorf("FindCredentials() error = %v", err)
 		return
 	}
-
 	if *creds != *fakeDrac {
 		t.Errorf("FindCredentials() didn't return a valid Credentials.")
 	}
 
+	// FindCredentials must fail if there is an error while retrieving
+	// credentials from Datastore.
 	mockClient.mustFail = true
 	_, err = FindCredentials(ctx, mockClient, testHost)
-
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")
 	}
 
+	// FindCredentials must return an error if there is no result for the
+	// requested hostname.
 	mockClient.mustFail = false
 	mockClient.skipAppend = true
-
 	_, err = FindCredentials(ctx, mockClient, testHost)
-
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")
 	}

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/datastore"
 )
 
+// DatastoreClientMock is a fake DatastoreClient for testing.
 type DatastoreClientMock struct {
 	Creds      []*Credentials
 	mustFail   bool

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -65,7 +65,7 @@ func TestFindCredentials(t *testing.T) {
 	}
 
 	mockClient.mustFail = true
-	creds, err = FindCredentials(ctx, mockClient, testHost)
+	_, err = FindCredentials(ctx, mockClient, testHost)
 
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")
@@ -74,7 +74,7 @@ func TestFindCredentials(t *testing.T) {
 	mockClient.mustFail = false
 	mockClient.skipAppend = true
 
-	creds, err = FindCredentials(ctx, mockClient, testHost)
+	_, err = FindCredentials(ctx, mockClient, testHost)
 
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")

--- a/storage/iface/iface.go
+++ b/storage/iface/iface.go
@@ -1,0 +1,14 @@
+package iface
+
+import (
+	"context"
+
+	"cloud.google.com/go/datastore"
+)
+
+// DatastoreClient is an interface to make testing possible. The default
+// implementation is the actual *datastore.Client as returned by
+// datastore.NewClient.
+type DatastoreClient interface {
+	GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error)
+}


### PR DESCRIPTION
This PR adds a `storage` package containing types and functions to retrieve credentials from Google Cloud Datastore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/2)
<!-- Reviewable:end -->
