### PR TITLE
Make Datastore's namespace configurable.

### DIFF
--- a/storage/datastore.go
+++ b/storage/datastore.go
@@ -23,16 +23,22 @@ type Credentials struct {
 	Address  string `datastore:"address"`
 }
 
+// Datastore is a struct holding the DatastoreClient and the namespace to use.
+type Datastore struct {
+	Client    iface.DatastoreClient
+	Namespace string
+}
+
 // FindCredentials retrieves a username/password pair from a DatastoreClient
 // for a given hostname.
-func FindCredentials(ctx context.Context, dc iface.DatastoreClient,
+func FindCredentials(ctx context.Context, ds Datastore,
 	host string) (*Credentials, error) {
 
-	query := datastore.NewQuery(datastoreKind)
+	query := datastore.NewQuery(datastoreKind).Namespace(ds.Namespace)
 	query = query.Filter("hostname = ", host)
 
 	var creds []*Credentials
-	_, err := dc.GetAll(ctx, query, &creds)
+	_, err := ds.Client.GetAll(ctx, query, &creds)
 
 	if err != nil {
 		return nil, err

--- a/storage/datastore_test.go
+++ b/storage/datastore_test.go
@@ -31,11 +31,12 @@ func (d mockDatastoreClient) GetAll(ctx context.Context, q *datastore.Query,
 }
 
 const (
-	testHost    = "test"
-	testUser    = "user"
-	testPass    = "pass"
-	testModel   = "drac"
-	testAddress = "addr"
+	testHost      = "test"
+	testUser      = "user"
+	testPass      = "pass"
+	testModel     = "drac"
+	testAddress   = "addr"
+	testNamespace = "test"
 )
 
 var fakeDrac = &Credentials{
@@ -48,14 +49,19 @@ var fakeDrac = &Credentials{
 
 func TestFindCredentials(t *testing.T) {
 	ctx := context.Background()
-	var mockClient = mockDatastoreClient{
+	var mockClient = &mockDatastoreClient{
 		Creds: []*Credentials{
 			fakeDrac,
 		},
 	}
 
+	var datastore = Datastore{
+		Client:    mockClient,
+		Namespace: testNamespace,
+	}
+
 	// FindCredentials must return valid credentials for a known hostname.
-	creds, err := FindCredentials(ctx, mockClient, testHost)
+	creds, err := FindCredentials(ctx, datastore, testHost)
 	if err != nil {
 		t.Errorf("FindCredentials() error = %v", err)
 		return
@@ -67,7 +73,7 @@ func TestFindCredentials(t *testing.T) {
 	// FindCredentials must fail if there is an error while retrieving
 	// credentials from Datastore.
 	mockClient.mustFail = true
-	_, err = FindCredentials(ctx, mockClient, testHost)
+	_, err = FindCredentials(ctx, datastore, testHost)
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")
 	}
@@ -76,7 +82,7 @@ func TestFindCredentials(t *testing.T) {
 	// requested hostname.
 	mockClient.mustFail = false
 	mockClient.skipAppend = true
-	_, err = FindCredentials(ctx, mockClient, testHost)
+	_, err = FindCredentials(ctx, datastore, testHost)
 	if err == nil {
 		t.Errorf("FindCredentials() didn't return an error as expected.")
 	}


### PR DESCRIPTION
This is needed to begin storing the Reboot API's Credentials into their own namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/3)
<!-- Reviewable:end -->
