### PR TITLE
Make hostname handling more flexible and add metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # reboot-service
 This reboot service allows to execute common operations on M-Lab platform's
-DRACs.
+BMC module (currently DRAC).
 
 It retrieves login credentials from Google Cloud Datastore.
 

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -14,8 +14,8 @@ import (
 type ConnType int
 
 const (
-	// DRACConnection is an SSH connection to the node's DRAC
-	DRACConnection ConnType = 0
+	// BMCConnection is an SSH connection to the node's BMC
+	BMCConnection ConnType = 0
 	// HostConnection is an SSH connection to the node's OS
 	HostConnection ConnType = 1
 )

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -14,10 +14,13 @@ import (
 type ConnType int
 
 const (
+	// UnspecifiedConnection is a connection with no type defined.
+	// This value should not be used.
+	UnspecifiedConnection ConnType = 0
 	// BMCConnection is an SSH connection to the node's BMC
-	BMCConnection ConnType = 0
+	BMCConnection ConnType = 1
 	// HostConnection is an SSH connection to the node's OS
-	HostConnection ConnType = 1
+	HostConnection ConnType = 2
 )
 
 // ConnectionConfig holds the configuration for a Connection

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -80,7 +80,7 @@ func Test_sshConnector_NewConnection(t *testing.T) {
 		Username:       "testuser",
 		Password:       "testpass",
 		PrivateKeyFile: "",
-		ConnType:       DRACConnection,
+		ConnType:       BMCConnection,
 	}
 
 	_, err := connector.NewConnection(config)
@@ -115,7 +115,7 @@ func Test_sshConnection_Reboot(t *testing.T) {
 		Username:       "testuser",
 		Password:       "testpass",
 		PrivateKeyFile: "",
-		ConnType:       DRACConnection,
+		ConnType:       BMCConnection,
 	}
 
 	conn, err := connector.NewConnection(config)
@@ -161,7 +161,7 @@ func Test_sshConnection_Close(t *testing.T) {
 		Username:       "testuser",
 		Password:       "testpass",
 		PrivateKeyFile: "",
-		ConnType:       DRACConnection,
+		ConnType:       BMCConnection,
 	}
 
 	conn, err := connector.NewConnection(config)

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ var (
 	projectID = flag.String("project", defaultProjID, "GCD project ID")
 	namespace = flag.String("namespace", defaultNamespace, "GCD namespace")
 	sshPort   = flag.Int("sshport", defaultSSHPort, "SSH port to use")
-	dracPort  = flag.Int("dracport", defaultDRACPort, "DRAC port to use")
+	bmcPort   = flag.Int("bmcport", defaultBMCPort, "BMC port to use")
 
 	// Context for the whole program.
 	ctx, cancel = context.WithCancel(context.Background())
@@ -40,7 +40,7 @@ const (
 	defaultProjID     = "mlab-sandbox"
 	defaultNamespace  = "reboot-api"
 	defaultSSHPort    = 22
-	defaultDRACPort   = 806
+	defaultBMCPort    = 806
 )
 
 func init() {
@@ -53,7 +53,7 @@ func createRebootConfig() *reboot.Config {
 		Namespace: *namespace,
 		ProjectID: *projectID,
 		SSHPort:   int32(*sshPort),
-		DRACPort:  int32(*dracPort),
+		BMCPort:   int32(*bmcPort),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ var (
 
 const (
 	defaultListenAddr = ":8080"
-	defaultPromPort   = ":8081"
+	defaultPromPort   = ":9600"
 	defaultProjID     = "mlab-sandbox"
 	defaultNamespace  = "reboot-api"
 	defaultSSHPort    = 22

--- a/main.go
+++ b/main.go
@@ -82,7 +82,8 @@ func main() {
 	defer s.Close()
 
 	// Initialize Prometheus server for monitoring.
-	prometheusx.MustStartPrometheus(*promAddr)
+	promServer := prometheusx.MustStartPrometheus(*promAddr)
+	defer promServer.Close()
 
 	// Keep serving until the context is canceled.
 	<-ctx.Done()

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -26,7 +26,7 @@ var (
 		},
 	)
 	metricBMCRebootTimeHist = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "reboot_drac_duration_seconds",
+		Name:    "reboot_bmc_duration_seconds",
 		Help:    "Duration histogram for successful BMC reboots, in seconds",
 		Buckets: []float64{15, 30, 45, 60},
 	})

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -8,6 +8,21 @@ import (
 	"github.com/apex/log"
 	"github.com/m-lab/reboot-service/connector"
 	"github.com/m-lab/reboot-service/creds"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricDRACReboots = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "reboot_drac_reboots_total",
+			Help: "Total number of successful DRAC reboots",
+		},
+		[]string{
+			"site",
+			"machine",
+		},
+	)
 )
 
 // Config holds the configuration for the reboot handler
@@ -72,6 +87,7 @@ func (h *Handler) rebootDRAC(ctx context.Context, host string) (string, error) {
 		return "", err
 	}
 
+	metricDRACReboots.WithLabelValues("TODO", "TODO").Inc()
 	return output, nil
 }
 

--- a/reboot/handler_test.go
+++ b/reboot/handler_test.go
@@ -75,12 +75,12 @@ func TestServeHTTP(t *testing.T) {
 		connectionMustFail bool
 	}{
 		{
-			req:    httptest.NewRequest("POST", "/v1/reboot?host=test", nil),
+			req:    httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t", nil),
 			status: http.StatusOK,
 			body:   "Server power operation successful",
 		},
 		{
-			req:    httptest.NewRequest("GET", "/v1/reboot?host=test", nil),
+			req:    httptest.NewRequest("GET", "/v1/reboot?host=mlab1.lga0t", nil),
 			status: http.StatusMethodNotAllowed,
 			body:   "",
 		},
@@ -90,22 +90,27 @@ func TestServeHTTP(t *testing.T) {
 			body:   "",
 		},
 		{
-			req:           httptest.NewRequest("POST", "/v1/reboot?host=test", nil),
+			req:           httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t", nil),
 			credsMustFail: true,
 			status:        http.StatusInternalServerError,
 			body:          "",
 		},
 		{
-			req:               httptest.NewRequest("POST", "/v1/reboot?host=test", nil),
+			req:               httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t", nil),
 			connectorMustFail: true,
 			status:            http.StatusInternalServerError,
 			body:              "",
 		},
 		{
-			req:                httptest.NewRequest("POST", "/v1/reboot?host=test", nil),
+			req:                httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t", nil),
 			connectionMustFail: true,
 			status:             http.StatusInternalServerError,
 			body:               "",
+		},
+		{
+			req:    httptest.NewRequest("POST", "/v1/reboot?host=thisshouldfail", nil),
+			status: http.StatusBadRequest,
+			body:   "The specified hostname is not a valid M-Lab node: thisshouldfail",
 		},
 	}
 

--- a/reboot/handler_test.go
+++ b/reboot/handler_test.go
@@ -120,7 +120,7 @@ func TestServeHTTP(t *testing.T) {
 		config: &Config{
 			ProjectID:      "test",
 			PrivateKeyPath: "",
-			DRACPort:       806,
+			BMCPort:        806,
 			SSHPort:        22,
 			Namespace:      "test",
 		},


### PR DESCRIPTION
Since there are multiple ways to specify a hostname to reboot, this change aims to handle to most common ones, i.e. the same we already accept in other tools (such as drac.py).

The following Prometheus metrics have also been added:
- reboot_drac_total{site, machine} is a counter containing the number of reboots
- reboot_drac_duration_seconds is a histogram containing the time it took to reboot a DRAC. Bucket size has been chosen empirically and can probably be improved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/5)
<!-- Reviewable:end -->
