### PR TITLE
Add CoreOS reboot via reboot-api user.

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -123,13 +123,26 @@ func (c *sshConnection) exec(cmd string) (string, error) {
 	return string(output), err
 }
 
+// Reboot reboots the node via this Connection. The method to perform the
+// reboot is chosen depending on sshConnection.ConnType.
 func (c *sshConnection) Reboot() (string, error) {
-	output, err := c.exec("racadm serveraction powercycle")
-	if err != nil {
-		log.Printf("Error executing reboot command: %v", err)
-		return "", err
+	var output string
+	var err error
+
+	if c.config.ConnType == HostConnection {
+		// To actually start an SSH session (and thus trigger a reboot) a
+		// command must be executed.
+		output, err = c.exec("")
+		if err != nil {
+			return "", err
+		}
+	} else { // reboot via DRAC (default)
+		output, err = c.exec("racadm serveraction powercycle")
+		if err != nil {
+			return "", err
+		}
 	}
-	return output, err
+	return output, nil
 }
 
 func (c *sshConnection) Close() error {

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -134,6 +134,9 @@ func (c *sshConnection) Reboot() (string, error) {
 	var err error
 
 	if c.config.ConnType == HostConnection {
+		// To reboot a host a "reboot-api" user is created, and the only way
+		// to authenticate is via a private key. Logging in with such user will
+		// automatically trigger a "systemctl reboot" command.
 		// To actually start an SSH session (and thus trigger a reboot) a
 		// command must be executed.
 		output, err = c.exec("")

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -1,6 +1,7 @@
 package connector
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -139,11 +140,13 @@ func (c *sshConnection) Reboot() (string, error) {
 		if err != nil {
 			return "", err
 		}
-	} else { // reboot via DRAC (default)
+	} else if c.config.ConnType == BMCConnection {
 		output, err = c.exec("racadm serveraction powercycle")
 		if err != nil {
 			return "", err
 		}
+	} else {
+		return "", errors.New("unable to reboot: unspecified connection")
 	}
 	return output, nil
 }

--- a/main.go
+++ b/main.go
@@ -29,8 +29,8 @@ var (
 	rebootUser = flag.String("reboot.user", defaultRebootUser, "User for rebooting CoreOS hosts")
 	keyPath    = flag.String("reboot.key", "", "SSH private key path")
 
-	sshPort  = flag.Int("reboot.sshport", defaultSSHPort, "SSH port to use")
-	bmcPort = flag.Int("reboot.bmcport", defaultDRACPort, "DRAC port to use")
+	sshPort = flag.Int("reboot.sshport", defaultSSHPort, "SSH port to use")
+	bmcPort = flag.Int("reboot.bmcport", defaultBMCPort, "DRAC port to use")
 
 	// Context for the whole program.
 	ctx, cancel = context.WithCancel(context.Background())
@@ -56,7 +56,7 @@ func createRebootConfig() *reboot.Config {
 		Namespace: *namespace,
 		ProjectID: *projectID,
 		SSHPort:   int32(*sshPort),
-		BMCPort:  int32(*dracPort),
+		BMCPort:   int32(*bmcPort),
 
 		RebootUser:     *rebootUser,
 		PrivateKeyPath: *keyPath,

--- a/main.go
+++ b/main.go
@@ -22,8 +22,6 @@ import (
 var (
 	// Command line flags.
 	listenAddr = flag.String("listenaddr", defaultListenAddr, "Address to listen on")
-	promAddr   = flag.String("promaddr", defaultPromPort,
-		"Address to listen on for Prometheus metrics")
 	projectID  = flag.String("datastore.project", defaultProjID, "GCD project ID")
 	namespace  = flag.String("datastore.namespace", defaultNamespace, "GCD namespace")
 	rebootUser = flag.String("reboot.user", defaultRebootUser, "User for rebooting CoreOS hosts")
@@ -89,7 +87,7 @@ func main() {
 	defer s.Close()
 
 	// Initialize Prometheus server for monitoring.
-	promServer := prometheusx.MustStartPrometheus(*promAddr)
+	promServer := prometheusx.MustServeMetrics()
 	defer promServer.Close()
 
 	// Keep serving until the context is canceled.

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 	rebootHandler := reboot.NewHandler(rebootConfig, credentials, connector)
 
 	// Initialize HTTP server.
+	// TODO(roberto): add promhttp instruments for handlers.
 	rebootMux := http.NewServeMux()
 	rebootMux.Handle("/v1/reboot", rebootHandler)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"net/http"
 
+	"github.com/apex/log"
 	"github.com/m-lab/reboot-service/connector"
 
 	"github.com/m-lab/reboot-service/creds"
@@ -16,8 +17,6 @@ import (
 	"github.com/m-lab/go/prometheusx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/reboot-service/reboot"
-
-	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -25,10 +24,13 @@ var (
 	listenAddr = flag.String("listenaddr", defaultListenAddr, "Address to listen on")
 	promAddr   = flag.String("promaddr", defaultPromPort,
 		"Address to listen on for Prometheus metrics")
-	projectID = flag.String("project", defaultProjID, "GCD project ID")
-	namespace = flag.String("namespace", defaultNamespace, "GCD namespace")
-	sshPort   = flag.Int("sshport", defaultSSHPort, "SSH port to use")
-	dracPort  = flag.Int("dracport", defaultDRACPort, "DRAC port to use")
+	projectID  = flag.String("datastore.project", defaultProjID, "GCD project ID")
+	namespace  = flag.String("datastore.namespace", defaultNamespace, "GCD namespace")
+	rebootUser = flag.String("reboot.user", defaultRebootUser, "User for rebooting CoreOS hosts")
+	keyPath    = flag.String("reboot.key", "", "SSH private key path")
+
+	sshPort  = flag.Int("reboot.sshport", defaultSSHPort, "SSH port to use")
+	dracPort = flag.Int("reboot.dracport", defaultDRACPort, "DRAC port to use")
 
 	// Context for the whole program.
 	ctx, cancel = context.WithCancel(context.Background())
@@ -41,10 +43,11 @@ const (
 	defaultNamespace  = "reboot-api"
 	defaultSSHPort    = 22
 	defaultDRACPort   = 806
+	defaultRebootUser = "reboot-api"
 )
 
 func init() {
-	log.SetLevel(log.DebugLevel)
+	log.SetLevel(log.InfoLevel)
 }
 
 func createRebootConfig() *reboot.Config {
@@ -54,6 +57,9 @@ func createRebootConfig() *reboot.Config {
 		ProjectID: *projectID,
 		SSHPort:   int32(*sshPort),
 		DRACPort:  int32(*dracPort),
+
+		RebootUser:     *rebootUser,
+		PrivateKeyPath: *keyPath,
 	}
 }
 

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -74,9 +74,6 @@ type Handler struct {
 }
 
 func (h *Handler) rebootHost(ctx context.Context, node string, site string) (string, error) {
-	// To reboot a host a "reboot-api" user is created, and the only way
-	// to authenticate is via a private key. Logging in with such user will
-	// automatically trigger a "systemctl reboot" command.
 	host := makeHostname(node, site)
 
 	// Connect to the host

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -182,7 +182,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	method := r.URL.Query().Get("method")
 	var output string
-	var err error
 	if method == "host" {
 		output, err = h.rebootHost(context.Background(), node, site)
 	} else { // default method is DRAC

--- a/reboot/handler_test.go
+++ b/reboot/handler_test.go
@@ -80,6 +80,10 @@ func TestServeHTTP(t *testing.T) {
 			body:   "Server power operation successful",
 		},
 		{
+			req:    httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t&method=host", nil),
+			status: http.StatusOK,
+		},
+		{
 			req:    httptest.NewRequest("GET", "/v1/reboot?host=mlab1.lga0t", nil),
 			status: http.StatusMethodNotAllowed,
 			body:   "",
@@ -103,6 +107,18 @@ func TestServeHTTP(t *testing.T) {
 		},
 		{
 			req:                httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t", nil),
+			connectionMustFail: true,
+			status:             http.StatusInternalServerError,
+			body:               "",
+		},
+		{
+			req:               httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t&method=host", nil),
+			connectorMustFail: true,
+			status:            http.StatusInternalServerError,
+			body:              "",
+		},
+		{
+			req:                httptest.NewRequest("POST", "/v1/reboot?host=mlab1.lga0t&method=host", nil),
 			connectionMustFail: true,
 			status:             http.StatusInternalServerError,
 			body:               "",


### PR DESCRIPTION
This PR adds the "host" reboot method to the `/v1/reboot` endpoint. Such method will execute a `systemctl reboot` on the CoreOS host by logging in via SSH with a previously defined `reboot-api` user and a private key. 

New metrics:
- `reboot_coreos_total{site, machine}`: number of reboots executed via the "host" method for a given node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/6)
<!-- Reviewable:end -->
