### PR TITLE
Add SSH connection timeout.

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
+	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -21,7 +22,8 @@ const (
 	// BMCConnection is an SSH connection to the node's BMC
 	BMCConnection ConnType = 1
 	// HostConnection is an SSH connection to the node's OS
-	HostConnection ConnType = 2
+	HostConnection    ConnType = 2
+	connectionTimeout          = 60 * time.Second
 )
 
 // ConnectionConfig holds the configuration for a Connection
@@ -77,6 +79,7 @@ func (s *sshConnector) NewConnection(config *ConnectionConfig) (Connection, erro
 		User:            config.Username,
 		Auth:            authMethods,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         connectionTimeout,
 	}
 
 	cl, err := s.dialer.Dial("tcp",


### PR DESCRIPTION
This should be significantly longer than the average time it takes to
connect to a DRAC and process the reboot command, and shorter than
the timeout set in clients (e.g. Rebot has a 2 minutes timeout).
The previous configuration - with no timeouts - apparently kept
retrying the connection more than once, which is less than ideal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/10)
<!-- Reviewable:end -->
