### PR TITLE
Add TLS support with autocert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN go get \
 
 # Now copy the built image into the minimal base image
 FROM alpine:3.7
+RUN apk add ca-certificates
 COPY --from=build /go/bin/reboot-service /
 WORKDIR /
 ENTRYPOINT ["/reboot-service"]

--- a/main.go
+++ b/main.go
@@ -128,8 +128,9 @@ func main() {
 
 		s.TLSConfig = &tls.Config{GetCertificate: m.GetCertificate}
 
-		// We also need a HTTP server listening on port 80 so that LetsEncrypt
-		// can authorize us.
+		// This HTTP server will listen for incoming http-01 challenges from
+		// LetsEncrypt. The only ports LetsEncrypt will send challenges to are
+		// 80 and 443, and this is not configurable.
 		httpServer := &http.Server{
 			Addr:    ":80",
 			Handler: m.HTTPHandler(nil),

--- a/main.go
+++ b/main.go
@@ -128,9 +128,18 @@ func main() {
 
 		s.TLSConfig = &tls.Config{GetCertificate: m.GetCertificate}
 
+		// We also need a HTTP server listening on port 80 so that LetsEncrypt
+		// can authorize us.
+		httpServer := makeHTTPServer(m.HTTPHandler(nil))
+		rtx.Must(httpx.ListenAndServeAsync(httpServer), "Could not start HTTP server")
+		defer httpServer.Close()
+
 		// Certificate and key file don't need to be specified as they will
 		// be generated or retrieved from the cache by autocert.
 		rtx.Must(httpx.ListenAndServeTLSAsync(s, "", ""), "Could not start HTTPS server")
+
+		// We also need a HTTP server on port 80 so that LetsEncrypt can
+		// authorize
 	} else {
 		rtx.Must(httpx.ListenAndServeAsync(s), "Could not start HTTP server")
 	}

--- a/main.go
+++ b/main.go
@@ -139,9 +139,6 @@ func main() {
 		// Certificate and key file don't need to be specified as they will
 		// be generated or retrieved from the cache by autocert.
 		rtx.Must(httpx.ListenAndServeTLSAsync(s, "", ""), "Could not start HTTPS server")
-
-		// We also need a HTTP server on port 80 so that LetsEncrypt can
-		// authorize
 	} else {
 		rtx.Must(httpx.ListenAndServeAsync(s), "Could not start HTTP server")
 	}

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func main() {
 		// We also need a HTTP server listening on port 80 so that LetsEncrypt
 		// can authorize us.
 		httpServer := &http.Server{
+			Addr:    ":80",
 			Handler: m.HTTPHandler(nil),
 		}
 		rtx.Must(httpx.ListenAndServeAsync(httpServer), "Could not start HTTP server")

--- a/main.go
+++ b/main.go
@@ -130,7 +130,9 @@ func main() {
 
 		// We also need a HTTP server listening on port 80 so that LetsEncrypt
 		// can authorize us.
-		httpServer := makeHTTPServer(m.HTTPHandler(nil))
+		httpServer := &http.Server{
+			Handler: m.HTTPHandler(nil),
+		}
 		rtx.Must(httpx.ListenAndServeAsync(httpServer), "Could not start HTTP server")
 		defer httpServer.Close()
 


### PR DESCRIPTION
This PR adds TLS support using LetsEncrypt and https://godoc.org/golang.org/x/crypto/acme/autocert.

Even if we're not going to use it in our current configuration, it could be useful in the future and it could serve as an example implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/11)
<!-- Reviewable:end -->
