### PR TITLE
Add a fake certs.Provider implementation for testing.

### DIFF
--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -1,0 +1,34 @@
+package credstest
+
+import (
+	"context"
+	"errors"
+
+	"github.com/m-lab/reboot-service/creds"
+)
+
+// FakeProvider is a fake provider to use for testing. It holds a map of
+// hostname -> *Credentials that can be populated as needed when testing.
+type FakeProvider struct {
+	creds map[string]*creds.Credentials
+}
+
+// NewProvider returns a FakeProvider.
+func NewProvider() *FakeProvider {
+	return &FakeProvider{}
+}
+
+// FindCredentials returns a Credentials from the creds map or an error.
+func (p *FakeProvider) FindCredentials(ctx context.Context,
+	host string) (*creds.Credentials, error) {
+	if cred, ok := p.creds[host]; ok {
+		return cred, nil
+	}
+
+	return nil, errors.New("hostname not found")
+}
+
+// AddCredentials adds a Credentials to the map.
+func (p *FakeProvider) AddCredentials(host string, cred *creds.Credentials) {
+	p.creds[host] = cred
+}

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -1,0 +1,57 @@
+package credstest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/m-lab/reboot-service/creds"
+)
+
+// Test the FakeProvider implementation.
+func TestFakeProvider_AddCredentials(t *testing.T) {
+	// Create a FakeProvider and add a Credentials to the map.
+	provider := &FakeProvider{
+		creds: map[string]*creds.Credentials{},
+	}
+
+	fakeDrac := &creds.Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider.AddCredentials("test", fakeDrac)
+	if creds, ok := provider.creds["test"]; !ok || creds != fakeDrac {
+		t.Errorf("AddCredentials() didn't add the expected Credentials.")
+	}
+}
+
+func TestFakeProvider_FindCredentials(t *testing.T) {
+	fakeDrac := &creds.Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider := &FakeProvider{
+		creds: map[string]*creds.Credentials{
+			"test": fakeDrac,
+		},
+	}
+
+	// Retrieve previously added Credentials from the FakeProvider's map.
+	creds, err := provider.FindCredentials(context.Background(), "test")
+	if err != nil || creds != fakeDrac {
+		t.Errorf("FindCredentials() returned an error or wrong Credentials.")
+	}
+
+	// Attempt to retrieve Credentials for an unknown hostname.
+	creds, err = provider.FindCredentials(context.Background(), "fail")
+	if err == nil || creds != nil {
+		t.Errorf("FindCredentials() didn't return an error.")
+	}
+}

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -55,3 +55,10 @@ func TestFakeProvider_FindCredentials(t *testing.T) {
 		t.Errorf("FindCredentials() didn't return an error.")
 	}
 }
+
+func TestNewProvider(t *testing.T) {
+	prov := NewProvider()
+	if prov == nil {
+		t.Errorf("NewProvider() returned nil.")
+	}
+}

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -34,8 +34,35 @@ type datastoreProvider struct {
 	connector connector
 }
 
+// FakeProvider is a fake provider to use for testing. It holds a map of
+// hostname -> *Credentials that can be populated as needed when testing.
+type FakeProvider struct {
+	creds map[string]*Credentials
+}
+
+// FindCredentials returns a Credentials from the creds map or an error.
+func (p *FakeProvider) FindCredentials(ctx context.Context,
+	host string) (*Credentials, error) {
+	if cred, ok := p.creds[host]; ok {
+		return cred, nil
+	}
+
+	return nil, errors.New("hostname not found")
+}
+
+// AddCredentials adds a Credentials to the map.
+func (p *FakeProvider) AddCredentials(host string, cred *Credentials) {
+	p.creds[host] = cred
+}
+
 // NewProvider returns a Provider based on the default implementation (GCD).
+// If the projectID and namespace are both "fake", it returns a fake
+// implementation that's useful for testing.
 func NewProvider(projectID, namespace string) Provider {
+	if projectID == "fake" && namespace == "fake" {
+		return &FakeProvider{}
+	}
+
 	return &datastoreProvider{
 		projectID: projectID,
 		namespace: namespace,

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -34,35 +34,8 @@ type datastoreProvider struct {
 	connector connector
 }
 
-// FakeProvider is a fake provider to use for testing. It holds a map of
-// hostname -> *Credentials that can be populated as needed when testing.
-type FakeProvider struct {
-	creds map[string]*Credentials
-}
-
-// FindCredentials returns a Credentials from the creds map or an error.
-func (p *FakeProvider) FindCredentials(ctx context.Context,
-	host string) (*Credentials, error) {
-	if cred, ok := p.creds[host]; ok {
-		return cred, nil
-	}
-
-	return nil, errors.New("hostname not found")
-}
-
-// AddCredentials adds a Credentials to the map.
-func (p *FakeProvider) AddCredentials(host string, cred *Credentials) {
-	p.creds[host] = cred
-}
-
 // NewProvider returns a Provider based on the default implementation (GCD).
-// If the projectID and namespace are both "fake", it returns a fake
-// implementation that's useful for testing.
 func NewProvider(projectID, namespace string) Provider {
-	if projectID == "fake" && namespace == "fake" {
-		return &FakeProvider{}
-	}
-
 	return &datastoreProvider{
 		projectID: projectID,
 		namespace: namespace,

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -47,12 +47,8 @@ func (d *mockClient) GetAll(ctx context.Context, q *datastore.Query,
 }
 
 func isFakeProvider(t interface{}) bool {
-	switch t.(type) {
-	case FakeProvider:
-		return true
-	default:
-		return false
-	}
+	_, ok := t.(*FakeProvider)
+	return ok
 }
 func TestNewProvider(t *testing.T) {
 	provider := NewProvider("projectID", "ns")
@@ -61,7 +57,7 @@ func TestNewProvider(t *testing.T) {
 	}
 
 	provider = NewProvider("fake", "fake")
-	if provider == nil || isFakeProvider(provider) {
+	if !isFakeProvider(provider) {
 		t.Errorf("NewProvider() didn't return a FakeProvider.")
 	}
 }

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -3,7 +3,6 @@ package creds
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 
 	"cloud.google.com/go/datastore"
@@ -46,19 +45,10 @@ func (d *mockClient) GetAll(ctx context.Context, q *datastore.Query,
 	return nil, nil
 }
 
-func isFakeProvider(t interface{}) bool {
-	_, ok := t.(*FakeProvider)
-	return ok
-}
 func TestNewProvider(t *testing.T) {
 	provider := NewProvider("projectID", "ns")
 	if provider == nil {
 		t.Errorf("NewProvider() returned nil.")
-	}
-
-	provider = NewProvider("fake", "fake")
-	if !isFakeProvider(provider) {
-		t.Errorf("NewProvider() didn't return a FakeProvider.")
 	}
 }
 
@@ -120,91 +110,4 @@ func TestFindCredentials(t *testing.T) {
 	}
 	mc.skipAppend = false
 
-}
-
-func Test_datastoreProvider_FindCredentials(t *testing.T) {
-	type fields struct {
-		projectID string
-		namespace string
-		connector connector
-	}
-	type args struct {
-		ctx  context.Context
-		host string
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    *Credentials
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			d := &datastoreProvider{
-				projectID: tt.fields.projectID,
-				namespace: tt.fields.namespace,
-				connector: tt.fields.connector,
-			}
-			got, err := d.FindCredentials(tt.args.ctx, tt.args.host)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("datastoreProvider.FindCredentials() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("datastoreProvider.FindCredentials() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-// Test the FakeProvider implementation.
-func TestFakeProvider_AddCredentials(t *testing.T) {
-	// Create a FakeProvider and add a Credentials to the map.
-	provider := &FakeProvider{
-		creds: map[string]*Credentials{},
-	}
-
-	fakeDrac := &Credentials{
-		Hostname: "host",
-		Username: "user",
-		Password: "pass",
-		Model:    "model",
-		Address:  "address",
-	}
-
-	provider.AddCredentials("test", fakeDrac)
-	if creds, ok := provider.creds["test"]; !ok || creds != fakeDrac {
-		t.Errorf("AddCredentials() didn't add the expected Credentials.")
-	}
-}
-
-func TestFakeProvider_FindCredentials(t *testing.T) {
-	fakeDrac := &Credentials{
-		Hostname: "host",
-		Username: "user",
-		Password: "pass",
-		Model:    "model",
-		Address:  "address",
-	}
-
-	provider := &FakeProvider{
-		creds: map[string]*Credentials{
-			"test": fakeDrac,
-		},
-	}
-
-	// Retrieve previously added Credentials from the FakeProvider's map.
-	creds, err := provider.FindCredentials(context.Background(), "test")
-	if err != nil || creds != fakeDrac {
-		t.Errorf("FindCredentials() returned an error or wrong Credentials.")
-	}
-
-	// Attempt to retrieve Credentials for an unknown hostname.
-	creds, err = provider.FindCredentials(context.Background(), "fail")
-	if err == nil || creds != nil {
-		t.Errorf("FindCredentials() didn't return an error.")
-	}
 }

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -3,11 +3,11 @@ package creds
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
-	"google.golang.org/api/option"
-
 	"cloud.google.com/go/datastore"
+	"google.golang.org/api/option"
 )
 
 type mockConnector struct {
@@ -46,10 +46,23 @@ func (d *mockClient) GetAll(ctx context.Context, q *datastore.Query,
 	return nil, nil
 }
 
+func isFakeProvider(t interface{}) bool {
+	switch t.(type) {
+	case FakeProvider:
+		return true
+	default:
+		return false
+	}
+}
 func TestNewProvider(t *testing.T) {
 	provider := NewProvider("projectID", "ns")
 	if provider == nil {
 		t.Errorf("NewProvider() returned nil.")
+	}
+
+	provider = NewProvider("fake", "fake")
+	if provider == nil || isFakeProvider(provider) {
+		t.Errorf("NewProvider() didn't return a FakeProvider.")
 	}
 }
 
@@ -111,4 +124,91 @@ func TestFindCredentials(t *testing.T) {
 	}
 	mc.skipAppend = false
 
+}
+
+func Test_datastoreProvider_FindCredentials(t *testing.T) {
+	type fields struct {
+		projectID string
+		namespace string
+		connector connector
+	}
+	type args struct {
+		ctx  context.Context
+		host string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *Credentials
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &datastoreProvider{
+				projectID: tt.fields.projectID,
+				namespace: tt.fields.namespace,
+				connector: tt.fields.connector,
+			}
+			got, err := d.FindCredentials(tt.args.ctx, tt.args.host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("datastoreProvider.FindCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("datastoreProvider.FindCredentials() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// Test the FakeProvider implementation.
+func TestFakeProvider_AddCredentials(t *testing.T) {
+	// Create a FakeProvider and add a Credentials to the map.
+	provider := &FakeProvider{
+		creds: map[string]*Credentials{},
+	}
+
+	fakeDrac := &Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider.AddCredentials("test", fakeDrac)
+	if creds, ok := provider.creds["test"]; !ok || creds != fakeDrac {
+		t.Errorf("AddCredentials() didn't add the expected Credentials.")
+	}
+}
+
+func TestFakeProvider_FindCredentials(t *testing.T) {
+	fakeDrac := &Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider := &FakeProvider{
+		creds: map[string]*Credentials{
+			"test": fakeDrac,
+		},
+	}
+
+	// Retrieve previously added Credentials from the FakeProvider's map.
+	creds, err := provider.FindCredentials(context.Background(), "test")
+	if err != nil || creds != fakeDrac {
+		t.Errorf("FindCredentials() returned an error or wrong Credentials.")
+	}
+
+	// Attempt to retrieve Credentials for an unknown hostname.
+	creds, err = provider.FindCredentials(context.Background(), "fail")
+	if err == nil || creds != nil {
+		t.Errorf("FindCredentials() didn't return an error.")
+	}
 }


### PR DESCRIPTION
This PR adds a fake `Provider` implementation for clients that use the `creds` package and want to unit test it without providing a custom mock. The FakeProvider is returned by `NewProvider` when `projectID` and `namespace` are both "fake".

It allows adding hostname -> Credentials pairs to a map and retrieve them through the `FindCredentials` method.

Closes #12.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/14)
<!-- Reviewable:end -->
