### PR TITLE
Implement Provider.AddCredentials

### DIFF
--- a/creds/connector.go
+++ b/creds/connector.go
@@ -12,6 +12,7 @@ import (
 // datastore.NewClient.
 type client interface {
 	GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error)
+	Put(context.Context, *datastore.Key, interface{}) (*datastore.Key, error)
 }
 
 type connector interface {

--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -9,13 +9,16 @@ import (
 
 // FakeProvider is a fake provider to use for testing. It holds a map of
 // hostname -> *Credentials that can be populated as needed when testing.
+// It can be set up to fail by changing its MustFail field.
 type FakeProvider struct {
 	creds map[string]*creds.Credentials
 }
 
 // NewProvider returns a FakeProvider.
 func NewProvider() *FakeProvider {
-	return &FakeProvider{}
+	return &FakeProvider{
+		creds: make(map[string]*creds.Credentials),
+	}
 }
 
 // FindCredentials returns a Credentials from the creds map or an error.

--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -9,7 +9,6 @@ import (
 
 // FakeProvider is a fake provider to use for testing. It holds a map of
 // hostname -> *Credentials that can be populated as needed when testing.
-// It can be set up to fail by changing its MustFail field.
 type FakeProvider struct {
 	creds map[string]*creds.Credentials
 }

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -22,7 +22,7 @@ func TestFakeProvider_AddCredentials(t *testing.T) {
 		Address:  "address",
 	}
 
-	provider.AddCredentials("test", fakeDrac)
+	provider.AddCredentials(context.Background(), "test", fakeDrac)
 	if creds, ok := provider.creds["test"]; !ok || creds != fakeDrac {
 		t.Errorf("AddCredentials() didn't add the expected Credentials.")
 	}

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -91,6 +91,7 @@ func (d *datastoreProvider) AddCredentials(ctx context.Context,
 	_, err = client.Put(ctx, key, creds)
 	if err != nil {
 		log.WithError(err).Errorf("Cannot add Credentials entity")
+		return err
 	}
 	return nil
 }

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -148,8 +148,11 @@ func TestAddCredentials(t *testing.T) {
 
 	// AddCredentials() should fail if the connection fails.
 	connector.mustFail = true
-	provider.AddCredentials(context.Background(), "testhost", fakeDrac)
+	err = provider.AddCredentials(context.Background(), "testhost", fakeDrac)
 	connector.mustFail = false
+	if err == nil {
+		t.Errorf("AddCredentials() expected error, got nil.")
+	}
 
 	// AddCredentials() should fail if the Put() fails.
 	mc.mustFail = true

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -45,6 +45,11 @@ func (d *mockClient) GetAll(ctx context.Context, q *datastore.Query,
 	return nil, nil
 }
 
+func (d *mockClient) Put(context.Context, *datastore.Key,
+	interface{}) (*datastore.Key, error) {
+	return nil, errors.New("not implemented")
+}
+
 func TestNewProvider(t *testing.T) {
 	provider := NewProvider("projectID", "ns")
 	if provider == nil {

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -47,7 +47,11 @@ func (d *mockClient) GetAll(ctx context.Context, q *datastore.Query,
 
 func (d *mockClient) Put(context.Context, *datastore.Key,
 	interface{}) (*datastore.Key, error) {
-	return nil, errors.New("not implemented")
+	if d.mustFail {
+		return nil, errors.New("method Put failed")
+	}
+
+	return nil, nil
 }
 
 func TestNewProvider(t *testing.T) {
@@ -115,4 +119,43 @@ func TestFindCredentials(t *testing.T) {
 	}
 	mc.skipAppend = false
 
+}
+
+func TestAddCredentials(t *testing.T) {
+	fakeDrac := &Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	// Create a datastoreProvider with a mock connector and client.
+	mc := &mockClient{}
+	connector := &mockConnector{
+		client: mc,
+	}
+	provider := &datastoreProvider{
+		connector: connector,
+		namespace: "ns",
+		projectID: "projectID",
+	}
+
+	err := provider.AddCredentials(context.Background(), "testhost", fakeDrac)
+	if err != nil {
+		t.Errorf("AddCredentials() unexpected error.")
+	}
+
+	// AddCredentials() should fail if the connection fails.
+	connector.mustFail = true
+	provider.AddCredentials(context.Background(), "testhost", fakeDrac)
+	connector.mustFail = false
+
+	// AddCredentials() should fail if the Put() fails.
+	mc.mustFail = true
+	err = provider.AddCredentials(context.Background(), "testhost", fakeDrac)
+	mc.mustFail = false
+	if err == nil {
+		t.Errorf("AddCredentials() expected error, got nil.")
+	}
 }

--- a/reboot/handler_test.go
+++ b/reboot/handler_test.go
@@ -44,24 +44,6 @@ func (connection *mockConnection) Close() error {
 	return nil
 }
 
-// Mock struct for credentials Provider
-// type mockProvider struct {
-// 	mustFail bool
-// }
-
-// func (p *mockProvider) FindCredentials(context.Context, string) (*creds.Credentials, error) {
-// 	if p.mustFail {
-// 		return nil, errors.New("method FindCredentials() failed")
-// 	}
-// 	return &creds.Credentials{
-// 		Hostname: "testhost",
-// 		Username: "testuser",
-// 		Password: "testpass",
-// 		Model:    "drac",
-// 		Address:  "testaddr",
-// 	}, nil
-// }
-
 func TestServeHTTP(t *testing.T) {
 	type fields struct {
 		status int


### PR DESCRIPTION
This PR implements an AddCredentials method that creates a Credentials entity on the underlying storage.

Additionally, it changes tests to use a `FakeProvider` instead of creating their own mock implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/15)
<!-- Reviewable:end -->
