### PR TITLE
Close SSH connections and sessions

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -121,6 +121,7 @@ func (c *sshConnection) exec(cmd string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer session.Close()
 
 	output, err := session.CombinedOutput(cmd)
 	if err != nil {

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -95,6 +95,7 @@ func (h *Handler) rebootHost(ctx context.Context, node string, site string) (str
 		metricHostReboots.WithLabelValues(site, node, "error-connect").Inc()
 		return "", err
 	}
+	defer conn.Close()
 
 	_, err = conn.Reboot()
 	if err != nil {
@@ -142,6 +143,7 @@ func (h *Handler) rebootBMC(ctx context.Context, node string, site string) (stri
 		metricBMCReboots.WithLabelValues(site, node, "error-connect").Inc()
 		return "", err
 	}
+	defer conn.Close()
 
 	start := time.Now()
 	output, err := conn.Reboot()


### PR DESCRIPTION
This PR makes sure `.Close()` is always called on SSH connections and sessions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/18)
<!-- Reviewable:end -->
