### PR TITLE
Implement E2E test stub

### DIFF
--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -43,8 +43,6 @@ func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
-	// TODO: actually try connecting to the BMC and report result.
-
 	// Get credentials for this BMC using the configured provider.
 	creds, err := c.getCredentials(c.target)
 	if err != nil {

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -1,19 +1,33 @@
 package e2e
 
 import (
+	"github.com/m-lab/reboot-service/connector"
+	"github.com/m-lab/reboot-service/creds"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	statusOK = "ok"
+)
+
+type collectorConfig struct {
+	provider  creds.Provider
+	connector connector.Connector
+}
+
 type bmcE2ECollector struct {
 	target       string
+	config       *collectorConfig
 	resultMetric *prometheus.Desc
 }
 
-func newBMCE2ECollector(target string) *bmcE2ECollector {
+func newBMCE2ECollector(target string, config *collectorConfig) *bmcE2ECollector {
 	return &bmcE2ECollector{
 		target: target,
+		config: config,
 		resultMetric: prometheus.NewDesc("reboot_e2e_result",
-			"E2E test result for this target", []string{"target"}, nil),
+			"E2E test result for this target", []string{"target", "status"},
+			nil),
 	}
 }
 
@@ -22,6 +36,7 @@ func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
-	// TODO: actual collect metrics from the BMC.
-	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue, 1, c.target)
+	// TODO: actually try connecting to the BMC and report result.
+	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue,
+		1, c.target, statusOK)
 }

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -23,5 +23,5 @@ func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
 	// TODO: actual collect metrics from the BMC.
-	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue, 1)
+	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue, 1, c.target)
 }

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -1,0 +1,27 @@
+package e2e
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type bmcE2ECollector struct {
+	target       string
+	resultMetric *prometheus.Desc
+}
+
+func newBMCE2ECollector(target string) *bmcE2ECollector {
+	return &bmcE2ECollector{
+		target: target,
+		resultMetric: prometheus.NewDesc("reboot_e2e_result",
+			"E2E test result for this target", []string{"target"}, nil),
+	}
+}
+
+func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.resultMetric
+}
+
+func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
+	// TODO: actual collect metrics from the BMC.
+	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue, 1)
+}

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -22,14 +22,14 @@ type collectorConfig struct {
 	connector connector.Connector
 }
 
-type bmcE2ECollector struct {
+type e2eTestCollector struct {
 	target       string
 	config       *collectorConfig
 	resultMetric *prometheus.Desc
 }
 
-func newBMCE2ECollector(target string, config *collectorConfig) *bmcE2ECollector {
-	return &bmcE2ECollector{
+func newE2ETestCollector(target string, config *collectorConfig) *e2eTestCollector {
+	return &e2eTestCollector{
 		target: target,
 		config: config,
 		resultMetric: prometheus.NewDesc("reboot_e2e_result",
@@ -38,11 +38,11 @@ func newBMCE2ECollector(target string, config *collectorConfig) *bmcE2ECollector
 	}
 }
 
-func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
+func (c *e2eTestCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.resultMetric
 }
 
-func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
+func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 	// Get credentials for this BMC using the configured provider.
 	creds, err := c.getCredentials(c.target)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
 		1, c.target, statusOK)
 }
 
-func (c *bmcE2ECollector) getCredentials(hostname string) (*creds.Credentials, error) {
+func (c *e2eTestCollector) getCredentials(hostname string) (*creds.Credentials, error) {
 	creds, err := c.config.provider.FindCredentials(context.Background(), hostname)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot retrieve credentials: %v", err)

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -1,16 +1,23 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
+
+	"github.com/apex/log"
 	"github.com/m-lab/reboot-service/connector"
 	"github.com/m-lab/reboot-service/creds"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (
-	statusOK = "ok"
+	statusOK               = "ok"
+	statusCredsNotFound    = "credentials_not_found"
+	statusConnectionFailed = "connection_failed"
 )
 
 type collectorConfig struct {
+	bmcPort   int32
 	provider  creds.Provider
 	connector connector.Connector
 }
@@ -37,6 +44,45 @@ func (c *bmcE2ECollector) Describe(ch chan<- *prometheus.Desc) {
 
 func (c *bmcE2ECollector) Collect(ch chan<- prometheus.Metric) {
 	// TODO: actually try connecting to the BMC and report result.
+
+	// Get credentials for this BMC using the configured provider.
+	creds, err := c.getCredentials(c.target)
+	if err != nil {
+		log.Errorf("Error while getting credentials for %s: %v", c.target, err)
+		ch <- prometheus.MustNewConstMetric(c.resultMetric,
+			prometheus.GaugeValue, 0, c.target, statusCredsNotFound)
+		return
+	}
+
+	// We've got credentials, let's try to SSH.
+	config := &connector.ConnectionConfig{
+		ConnType: connector.BMCConnection,
+		Hostname: c.target,
+		Port:     c.config.bmcPort,
+		Username: creds.Username,
+		Password: creds.Password,
+	}
+	conn, err := c.config.connector.NewConnection(config)
+	if err != nil {
+		// TODO: here we should be able to distinguish different errors.
+		log.Errorf("Error while creating connection to %s: %v", c.target, err)
+		ch <- prometheus.MustNewConstMetric(c.resultMetric,
+			prometheus.GaugeValue, 0, c.target, statusConnectionFailed)
+		return
+	}
+
+	// TODO: execute a no-op command?
+	conn.Close()
+
 	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue,
 		1, c.target, statusOK)
+}
+
+func (c *bmcE2ECollector) getCredentials(hostname string) (*creds.Credentials, error) {
+	creds, err := c.config.provider.FindCredentials(context.Background(), hostname)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot retrieve credentials: %v", err)
+	}
+
+	return creds, nil
 }

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -18,8 +18,7 @@ import (
 
 // Mock structs for Connector and Connection interfaces.
 type mockConnector struct {
-	mustFail     bool
-	connMustFail bool
+	mustFail bool
 }
 
 type mockConnection struct {
@@ -30,9 +29,7 @@ func (connector *mockConnector) NewConnection(*connector.ConnectionConfig) (conn
 	if connector.mustFail {
 		return nil, errors.New("method NewConnection() failed")
 	}
-	return &mockConnection{
-		mustFail: connector.connMustFail,
-	}, nil
+	return &mockConnection{}, nil
 }
 
 func (connection *mockConnection) Reboot() (string, error) {

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -1,0 +1,149 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/m-lab/reboot-service/connector"
+	"github.com/m-lab/reboot-service/creds/credstest"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Mock structs for Connector and Connection interfaces.
+type mockConnector struct {
+	mustFail     bool
+	connMustFail bool
+}
+
+type mockConnection struct {
+	mustFail bool
+}
+
+func (connector *mockConnector) NewConnection(*connector.ConnectionConfig) (connector.Connection, error) {
+	if connector.mustFail {
+		return nil, errors.New("method NewConnection() failed")
+	}
+	return &mockConnection{
+		mustFail: connector.connMustFail,
+	}, nil
+}
+
+func (connection *mockConnection) Reboot() (string, error) {
+	return "Not implemented", nil
+}
+
+func (connection *mockConnection) Close() error {
+	return nil
+}
+
+func Test_newE2ETestCollector(t *testing.T) {
+	config := &collectorConfig{
+		bmcPort:   806,
+		connector: &mockConnector{},
+		provider:  credstest.NewProvider(),
+	}
+
+	collector := newE2ETestCollector("mlab1.lga0t.measurement-lab.org", config)
+	if collector == nil {
+		t.Errorf("newE2ETestCollector() returned nil.")
+	}
+}
+
+func Test_e2eTestCollector_Collect(t *testing.T) {
+	provider := credstest.NewProvider()
+	connector := &mockConnector{}
+	provider.AddCredentials(context.Background(),
+		"mlab1d.lga0t.measurement-lab.org", &creds.Credentials{
+			Hostname: "mlab1d.lga0t.measurement-lab.org",
+			Username: "admin",
+			Password: "dummy",
+		})
+	config := &collectorConfig{
+		bmcPort:   806,
+		connector: connector,
+		provider:  provider,
+	}
+	collector := newE2ETestCollector("mlab1d.lga0t.measurement-lab.org", config)
+
+	// Compare actual vs expected output in the "ok" case.
+	expMetadata := `# HELP reboot_e2e_result E2E test result for this target
+# TYPE reboot_e2e_result gauge
+
+`
+	expMetric := `
+reboot_e2e_result{status="` + statusOK + `",target="mlab1d.lga0t.measurement-lab.org"} 1
+`
+	err := testutil.CollectAndCompare(collector, strings.NewReader(
+		expMetadata+expMetric))
+	if err != nil {
+		t.Errorf("CollectAndCompare() returned err: %v", err)
+	}
+
+	// COmpare actual vs expected output in the "connection_failed" case.
+	expMetric = `
+reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.lga0t.measurement-lab.org"} 0
+`
+	connector.mustFail = true
+	collector = newE2ETestCollector("mlab1d.lga0t.measurement-lab.org", config)
+	err = testutil.CollectAndCompare(collector, strings.NewReader(
+		expMetadata+expMetric))
+	if err != nil {
+		t.Errorf("CollectAndCompare() returned err: %v", err)
+	}
+
+	// Compare actual vs expected output in the "credentials_not_found" case.
+	expMetric = `
+reboot_e2e_result{status="` + statusCredsNotFound + `",target="mlab2d.lga0t.measurement-lab.org"} 0
+`
+	collector = newE2ETestCollector("mlab2d.lga0t.measurement-lab.org", config)
+	err = testutil.CollectAndCompare(collector, strings.NewReader(
+		expMetadata+expMetric))
+	if err != nil {
+		t.Errorf("CollectAndCompare() returned err: %v", err)
+	}
+
+}
+
+func Test_e2eTestCollector_getCredentials(t *testing.T) {
+	type fields struct {
+		target       string
+		config       *collectorConfig
+		resultMetric *prometheus.Desc
+	}
+	type args struct {
+		hostname string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *creds.Credentials
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &e2eTestCollector{
+				target:       tt.fields.target,
+				config:       tt.fields.config,
+				resultMetric: tt.fields.resultMetric,
+			}
+			got, err := c.getCredentials(tt.args.hostname)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("e2eTestCollector.getCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("e2eTestCollector.getCredentials() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -47,7 +47,7 @@ func Test_newE2ETestCollector(t *testing.T) {
 		provider:  credstest.NewProvider(),
 	}
 
-	collector := newE2ETestCollector("mlab1.lga0t.measurement-lab.org", config)
+	collector := newE2ETestCollector("mlab1.abc0t.measurement-lab.org", config)
 	if collector == nil {
 		t.Errorf("newE2ETestCollector() returned nil.")
 	}
@@ -57,8 +57,8 @@ func Test_e2eTestCollector_Collect(t *testing.T) {
 	provider := credstest.NewProvider()
 	connector := &mockConnector{}
 	provider.AddCredentials(context.Background(),
-		"mlab1d.lga0t.measurement-lab.org", &creds.Credentials{
-			Hostname: "mlab1d.lga0t.measurement-lab.org",
+		"mlab1d.abc0t.measurement-lab.org", &creds.Credentials{
+			Hostname: "mlab1d.abc0t.measurement-lab.org",
 			Username: "admin",
 			Password: "dummy",
 		})
@@ -67,7 +67,7 @@ func Test_e2eTestCollector_Collect(t *testing.T) {
 		connector: connector,
 		provider:  provider,
 	}
-	collector := newE2ETestCollector("mlab1d.lga0t.measurement-lab.org", config)
+	collector := newE2ETestCollector("mlab1d.abc0t.measurement-lab.org", config)
 
 	// Compare actual vs expected output in the "ok" case.
 	expMetadata := `# HELP reboot_e2e_result E2E test result for this target
@@ -75,7 +75,7 @@ func Test_e2eTestCollector_Collect(t *testing.T) {
 
 `
 	expMetric := `
-reboot_e2e_result{status="` + statusOK + `",target="mlab1d.lga0t.measurement-lab.org"} 1
+reboot_e2e_result{status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 1
 `
 	err := testutil.CollectAndCompare(collector, strings.NewReader(
 		expMetadata+expMetric))
@@ -85,10 +85,10 @@ reboot_e2e_result{status="` + statusOK + `",target="mlab1d.lga0t.measurement-lab
 
 	// COmpare actual vs expected output in the "connection_failed" case.
 	expMetric = `
-reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.lga0t.measurement-lab.org"} 0
+reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.abc0t.measurement-lab.org"} 0
 `
 	connector.mustFail = true
-	collector = newE2ETestCollector("mlab1d.lga0t.measurement-lab.org", config)
+	collector = newE2ETestCollector("mlab1d.abc0t.measurement-lab.org", config)
 	err = testutil.CollectAndCompare(collector, strings.NewReader(
 		expMetadata+expMetric))
 	if err != nil {
@@ -97,9 +97,9 @@ reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.lga0t.m
 
 	// Compare actual vs expected output in the "credentials_not_found" case.
 	expMetric = `
-reboot_e2e_result{status="` + statusCredsNotFound + `",target="mlab2d.lga0t.measurement-lab.org"} 0
+reboot_e2e_result{status="` + statusCredsNotFound + `",target="mlab2d.abc0t.measurement-lab.org"} 0
 `
-	collector = newE2ETestCollector("mlab2d.lga0t.measurement-lab.org", config)
+	collector = newE2ETestCollector("mlab2d.abc0t.measurement-lab.org", config)
 	err = testutil.CollectAndCompare(collector, strings.NewReader(
 		expMetadata+expMetric))
 	if err != nil {

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -65,8 +65,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	collectorConfig := &collectorConfig{
+		connector: h.connector,
+		provider:  h.provider,
+	}
+
 	registry := prometheus.NewRegistry()
-	collector := newBMCE2ECollector(bmcHost)
+	collector := newBMCE2ECollector(bmcHost, collectorConfig)
 	registry.MustRegister(collector)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	promHandler.ServeHTTP(w, r)

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	collector := newBMCE2ECollector(bmcHost, collectorConfig)
+	collector := newE2ECollector(bmcHost, collectorConfig)
 	registry.MustRegister(collector)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	promHandler.ServeHTTP(w, r)

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -15,6 +15,8 @@ import (
 	"github.com/m-lab/reboot-service/creds"
 )
 
+var bmcHostRegex = regexp.MustCompile("(mlab[1-4]d)\\.([a-zA-Z]{3}[0-9t]{2}).*")
+
 // Handler is the HTTP handler for /e2e
 type Handler struct {
 	bmcPort int32
@@ -75,8 +77,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // parseBMCHostname matches the provided hostname against a regex and returns
 // a full valid M-Lab BMC hostname, if possible.
 func parseBMCHostname(hostname string) (string, error) {
-	regex := regexp.MustCompile("(mlab[1-4]d)\\.([a-zA-Z]{3}[0-9t]{2}).*")
-	result := regex.FindStringSubmatch(hostname)
+	result := bmcHostRegex.FindStringSubmatch(hostname)
 	if len(result) != 3 {
 		return "",
 			fmt.Errorf("The specified hostname is not a valid BMC hostname: %s", hostname)

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -15,24 +15,18 @@ import (
 	"github.com/m-lab/reboot-service/creds"
 )
 
-// Config holds the configuration for the e2e endpoint.
-type Config struct {
-	// Datastore configuration
-	ProjectID string
-	Namespace string
-}
-
 // Handler is the HTTP handler for /e2e
 type Handler struct {
-	config    *Config
+	bmcPort int32
+
 	connector connector.Connector
 	provider  creds.Provider
 }
 
 // NewHandler returns a Handler with the specified configuration.
-func NewHandler(c *Config, prov creds.Provider, connector connector.Connector) *Handler {
+func NewHandler(bmcPort int32, prov creds.Provider, connector connector.Connector) *Handler {
 	return &Handler{
-		config:    c,
+		bmcPort:   bmcPort,
 		connector: connector,
 		provider:  prov,
 	}
@@ -66,6 +60,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	collectorConfig := &collectorConfig{
+		bmcPort:   h.bmcPort,
 		connector: h.connector,
 		provider:  h.provider,
 	}

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -1,0 +1,86 @@
+// Package e2e contains the handler to perform an end-to-end connectivity test
+// on a given BMC module on the M-Lab infrastructure.
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/apex/log"
+	"github.com/m-lab/reboot-service/connector"
+	"github.com/m-lab/reboot-service/creds"
+)
+
+// Config holds the configuration for the e2e endpoint.
+type Config struct {
+	// Datastore configuration
+	ProjectID string
+	Namespace string
+}
+
+// Handler is the HTTP handler for /e2e
+type Handler struct {
+	config    *Config
+	connector connector.Connector
+	provider  creds.Provider
+}
+
+// NewHandler returns a Handler with the specified configuration.
+func NewHandler(c *Config, prov creds.Provider, connector connector.Connector) *Handler {
+	return &Handler{
+		config:    c,
+		connector: connector,
+		provider:  prov,
+	}
+}
+
+// ServeHTTP handles GET requests to the /e2e endpoint, parsing the target
+// parameter and delegating writing the actual response to promhttp.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	target := r.URL.Query().Get("target")
+	if len(target) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("URL parameter 'target' is missing"))
+		log.Info("URL parameter 'target' is missing")
+		return
+	}
+
+	// Parses the target parameter. If a valid BMC hostname cannot be extracted
+	// we are reasonably sure this is not a valid M-Lab node's BMC.
+	bmcHost, err := parseBMCHostname(target)
+	if err != nil {
+		errStr := fmt.Sprintf(target)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(errStr))
+		log.Errorf(errStr)
+		return
+	}
+
+	registry := prometheus.NewRegistry()
+	collector := newBMCE2ECollector(bmcHost)
+	registry.MustRegister(collector)
+	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	promHandler.ServeHTTP(w, r)
+}
+
+// parseBMCHostname matches the provided hostname against a regex and returns
+// a full valid M-Lab BMC hostname, if possible.
+func parseBMCHostname(hostname string) (string, error) {
+	regex := regexp.MustCompile("(mlab[1-4]d)\\.([a-zA-Z]{3}[0-9t]{2}).*")
+	result := regex.FindStringSubmatch(hostname)
+	if len(result) != 3 {
+		return "",
+			fmt.Errorf("The specified hostname is not a valid BMC hostname: %s", hostname)
+	}
+
+	return fmt.Sprintf("%s.%s.measurement-lab.org", result[1], result[2]), nil
+}

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -66,7 +66,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	collector := newE2ECollector(bmcHost, collectorConfig)
+	collector := newE2ETestCollector(bmcHost, collectorConfig)
 	registry.MustRegister(collector)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	promHandler.ServeHTTP(w, r)

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -31,29 +31,29 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		connectorMustFail bool
 	}{
 		{
-			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.lga0t", nil),
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t", nil),
 			status: http.StatusOK,
 			body: expMetadata + `reboot_e2e_result{status="` + statusOK +
-				`",target="mlab1d.lga0t.measurement-lab.org"} 1
+				`",target="mlab1d.abc0t.measurement-lab.org"} 1
 `,
 		},
 		{
-			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.lga0t", nil),
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.abc0t", nil),
 			status: http.StatusOK,
 			body: expMetadata + `reboot_e2e_result{status="` + statusCredsNotFound +
-				`",target="mlab2d.lga0t.measurement-lab.org"} 0
+				`",target="mlab2d.abc0t.measurement-lab.org"} 0
 `,
 		},
 		{
-			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.lga0t", nil),
+			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t", nil),
 			status:            http.StatusOK,
 			connectorMustFail: true,
 			body: expMetadata + `reboot_e2e_result{status="` + statusConnectionFailed +
-				`",target="mlab1d.lga0t.measurement-lab.org"} 0
+				`",target="mlab1d.abc0t.measurement-lab.org"} 0
 `,
 		},
 		{
-			req:    httptest.NewRequest("POST", "/v1/e2e?target=mlab1d.lga0t", nil),
+			req:    httptest.NewRequest("POST", "/v1/e2e?target=mlab1d.abc0t", nil),
 			status: http.StatusMethodNotAllowed,
 		},
 		{
@@ -71,8 +71,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	// Create a FakeProvider and populate it with fake Credentials.
 	provider := credstest.NewProvider()
 	provider.AddCredentials(context.Background(),
-		"mlab1d.lga0t.measurement-lab.org", &creds.Credentials{
-			Hostname: "mlab1.lga0t",
+		"mlab1d.abc0t.measurement-lab.org", &creds.Credentials{
+			Hostname: "mlab1.abc0t",
 			Username: "testuser",
 			Password: "testpass",
 			Model:    "drac",

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -117,20 +117,36 @@ func TestHandler_ServeHTTP(t *testing.T) {
 }
 
 func Test_parseBMCHostname(t *testing.T) {
-	type args struct {
-		hostname string
-	}
 	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
+		name     string
+		hostname string
+		want     string
+		wantErr  bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:     "ok-full-hostname",
+			hostname: "mlab1d.abc0t.measurement-lab.org",
+			want:     "mlab1d.abc0t.measurement-lab.org",
+		},
+		{
+			name:     "ok-shorthand-hostname",
+			hostname: "mlab1d.abc0t",
+			want:     "mlab1d.abc0t.measurement-lab.org",
+		},
+		{
+			name:     "failure-wrong-node-name",
+			hostname: "mlab1.abc0t",
+			wantErr:  true,
+		},
+		{
+			name:     "failure-wrong-site-name",
+			hostname: "mlab1d.abc0",
+			wantErr:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseBMCHostname(tt.args.hostname)
+			got, err := parseBMCHostname(tt.hostname)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseBMCHostname() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -1,0 +1,143 @@
+// Package e2e contains the handler to perform an end-to-end connectivity test
+// on a given BMC module on the M-Lab infrastructure.
+package e2e
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/m-lab/reboot-service/creds"
+	"github.com/m-lab/reboot-service/creds/credstest"
+)
+
+func TestNewHandler(t *testing.T) {
+	handler := NewHandler(806, credstest.NewProvider(), &mockConnector{})
+	if handler == nil {
+		t.Errorf("NewHandler() returned nil.")
+	}
+}
+
+func TestHandler_ServeHTTP(t *testing.T) {
+	expMetadata := `# HELP reboot_e2e_result E2E test result for this target
+# TYPE reboot_e2e_result gauge
+`
+	tests := []struct {
+		req               *http.Request
+		status            int
+		body              string
+		connectorMustFail bool
+	}{
+		{
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.lga0t", nil),
+			status: http.StatusOK,
+			body: expMetadata + `reboot_e2e_result{status="` + statusOK +
+				`",target="mlab1d.lga0t.measurement-lab.org"} 1
+`,
+		},
+		{
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.lga0t", nil),
+			status: http.StatusOK,
+			body: expMetadata + `reboot_e2e_result{status="` + statusCredsNotFound +
+				`",target="mlab2d.lga0t.measurement-lab.org"} 0
+`,
+		},
+		{
+			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.lga0t", nil),
+			status:            http.StatusOK,
+			connectorMustFail: true,
+			body: expMetadata + `reboot_e2e_result{status="` + statusConnectionFailed +
+				`",target="mlab1d.lga0t.measurement-lab.org"} 0
+`,
+		},
+		{
+			req:    httptest.NewRequest("POST", "/v1/e2e?target=mlab1d.lga0t", nil),
+			status: http.StatusMethodNotAllowed,
+		},
+		{
+			req:    httptest.NewRequest("GET", "/v1/e2e", nil),
+			status: http.StatusBadRequest,
+		},
+		{
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=thisshouldfail", nil),
+			status: http.StatusBadRequest,
+		},
+	}
+
+	connector := &mockConnector{}
+
+	// Create a FakeProvider and populate it with fake Credentials.
+	provider := credstest.NewProvider()
+	provider.AddCredentials(context.Background(),
+		"mlab1d.lga0t.measurement-lab.org", &creds.Credentials{
+			Hostname: "mlab1.lga0t",
+			Username: "testuser",
+			Password: "testpass",
+			Model:    "drac",
+			Address:  "testaddr",
+		})
+
+	h := &Handler{
+		bmcPort:   806,
+		connector: connector,
+		provider:  provider,
+	}
+
+	for _, test := range tests {
+		rr := httptest.NewRecorder()
+
+		connector.mustFail = test.connectorMustFail
+
+		h.ServeHTTP(rr, test.req)
+
+		connector.mustFail = false
+
+		resp := rr.Result()
+
+		// Test StatusCode and Body against the expected values.
+		if resp.StatusCode != test.status {
+			t.Errorf("ServeHTTP - expected %d, got %d", test.status,
+				resp.StatusCode)
+		}
+
+		if test.body != "" {
+			body, err := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Errorf("ServeHTTP() - cannot read response: %v", err)
+			}
+			if string(body) != test.body {
+				t.Errorf("ServeHTTP() - unexpected response: %s", string(body))
+			}
+		}
+	}
+
+}
+
+func Test_parseBMCHostname(t *testing.T) {
+	type args struct {
+		hostname string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBMCHostname(tt.args.hostname)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseBMCHostname() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("parseBMCHostname() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/m-lab/reboot-service/connector"
+	"github.com/m-lab/reboot-service/e2e"
 
 	"github.com/m-lab/reboot-service/creds"
 
@@ -92,8 +93,12 @@ func main() {
 	credentials := creds.NewProvider(*projectID, *namespace)
 	connector := connector.NewConnector()
 
-	var rebootHandler http.Handler
+	var (
+		rebootHandler  http.Handler
+		bmcTestHandler http.Handler
+	)
 	rebootHandler = reboot.NewHandler(rebootConfig, credentials, connector)
+	bmcTestHandler = e2e.NewHandler(nil, credentials, connector)
 
 	// Initialize HTTP server.
 	// TODO(roberto): add promhttp instruments for handlers.
@@ -104,6 +109,7 @@ func main() {
 			Password: *password,
 		}
 		rebootHandler = httpauth.BasicAuth(authOpts)(rebootHandler)
+		bmcTestHandler = httpauth.BasicAuth(authOpts)(bmcTestHandler)
 	} else {
 		log.Warn("Username and password have not been specified!")
 		log.Warn("Make sure you add -auth.username and -auth.password before " +
@@ -112,6 +118,7 @@ func main() {
 
 	rebootMux := http.NewServeMux()
 	rebootMux.Handle("/v1/reboot", rebootHandler)
+	rebootMux.Handle("/v1/e2e", bmcTestHandler)
 
 	s := makeHTTPServer(rebootMux)
 	// Setup TLS and autocert

--- a/main.go
+++ b/main.go
@@ -94,11 +94,11 @@ func main() {
 	connector := connector.NewConnector()
 
 	var (
-		rebootHandler  http.Handler
-		bmcTestHandler http.Handler
+		rebootHandler http.Handler
+		e2eHandler    http.Handler
 	)
 	rebootHandler = reboot.NewHandler(rebootConfig, credentials, connector)
-	bmcTestHandler = e2e.NewHandler(nil, credentials, connector)
+	e2eHandler = e2e.NewHandler(int32(*bmcPort), credentials, connector)
 
 	// Initialize HTTP server.
 	// TODO(roberto): add promhttp instruments for handlers.
@@ -109,7 +109,7 @@ func main() {
 			Password: *password,
 		}
 		rebootHandler = httpauth.BasicAuth(authOpts)(rebootHandler)
-		bmcTestHandler = httpauth.BasicAuth(authOpts)(bmcTestHandler)
+		e2eHandler = httpauth.BasicAuth(authOpts)(e2eHandler)
 	} else {
 		log.Warn("Username and password have not been specified!")
 		log.Warn("Make sure you add -auth.username and -auth.password before " +
@@ -118,7 +118,7 @@ func main() {
 
 	rebootMux := http.NewServeMux()
 	rebootMux.Handle("/v1/reboot", rebootHandler)
-	rebootMux.Handle("/v1/e2e", bmcTestHandler)
+	rebootMux.Handle("/v1/e2e", e2eHandler)
 
 	s := makeHTTPServer(rebootMux)
 	// Setup TLS and autocert


### PR DESCRIPTION
This PR adds the `/v1/e2e` endpoint, taking a BMC module's hostname as the `target` argument.

There are at least two possible improvements:
- Cache results, to avoid hitting the BMCs with too many connections if multiple Prometheus instances scrape the same targets
- Consider different subcases for "connection failed": DNS resolution failure, timeout, unable to log in, etc

However, some things need to be discussed first and some things would make this PR much bigger, so here is a basic implementation of a custom Prometheus collector that:
1. Gets credentials from Datastore
2. Attempts to SSH into a BMC 
3. Returns a `reboot_e2e_result{status=...,target=...}` metric, with possible statuses `ok`, `connection_failed` or `credentials_not_found`

It already makes for a pretty big diff, but most of it is test code that's borrowed from `reboot/handler_test.go` and works in the same way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/20)
<!-- Reviewable:end -->
