### PR TITLE
Set explicit timeouts for BMC SSH connections

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -22,8 +22,7 @@ const (
 	// BMCConnection is an SSH connection to the node's BMC
 	BMCConnection ConnType = 1
 	// HostConnection is an SSH connection to the node's OS
-	HostConnection    ConnType = 2
-	connectionTimeout          = 60 * time.Second
+	HostConnection ConnType = 2
 )
 
 // ConnectionConfig holds the configuration for a Connection
@@ -35,6 +34,7 @@ type ConnectionConfig struct {
 	PrivateKeyFile string
 
 	ConnType ConnType
+	Timeout  time.Duration
 }
 
 // Connector is a provider for Connections.
@@ -79,7 +79,7 @@ func (s *sshConnector) NewConnection(config *ConnectionConfig) (Connection, erro
 		User:            config.Username,
 		Auth:            authMethods,
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         connectionTimeout,
+		Timeout:         config.Timeout,
 	}
 
 	cl, err := s.dialer.Dial("tcp",

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -16,6 +16,7 @@ const (
 	statusCredsNotFound    = "credentials_not_found"
 	statusConnectionFailed = "connection_failed"
 
+	// Timeout for the e2e test must be shorter than Prometheus' timeout.
 	connectionTimeout = 45 * time.Second
 )
 

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/m-lab/reboot-service/connector"
@@ -14,6 +15,8 @@ const (
 	statusOK               = "ok"
 	statusCredsNotFound    = "credentials_not_found"
 	statusConnectionFailed = "connection_failed"
+
+	connectionTimeout = 45 * time.Second
 )
 
 type collectorConfig struct {
@@ -59,6 +62,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 		Port:     c.config.bmcPort,
 		Username: creds.Username,
 		Password: creds.Password,
+		Timeout:  connectionTimeout,
 	}
 	conn, err := c.config.connector.NewConnection(config)
 	if err != nil {

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const bmcTimeout = 60 * time.Second
+
 var (
 	metricBMCReboots = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -133,6 +135,7 @@ func (h *Handler) rebootBMC(ctx context.Context, node string, site string) (stri
 		Port:           h.config.BMCPort,
 		PrivateKeyFile: h.config.PrivateKeyPath,
 		ConnType:       connector.BMCConnection,
+		Timeout:        bmcTimeout,
 	}
 
 	conn, err := h.connector.NewConnection(connectionConfig)


### PR DESCRIPTION
This PR adds `Timeout` as a field in the `connector.ConnectionConfig` struct so that the SSH connection timeout can be configured. It was previously a constant set to 60 seconds, which doesn't work well with Prometheus' scraping timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/22)
<!-- Reviewable:end -->
