### PR TITLE
Add DeleteCredentials() method to provider

### DIFF
--- a/creds/connector.go
+++ b/creds/connector.go
@@ -13,6 +13,7 @@ import (
 type client interface {
 	GetAll(ctx context.Context, q *datastore.Query, dst interface{}) ([]*datastore.Key, error)
 	Put(context.Context, *datastore.Key, interface{}) (*datastore.Key, error)
+	Delete(context.Context, *datastore.Key) error
 	Close() error
 }
 

--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -36,3 +36,11 @@ func (p *FakeProvider) AddCredentials(ctx context.Context, host string,
 	p.creds[host] = cred
 	return nil
 }
+
+// DeleteCredentials removes a Credentials from the map.
+func (p *FakeProvider) DeleteCredentials(ctx context.Context, host string) error {
+	if _, ok := p.creds[host]; ok {
+		delete(p.creds, host)
+	}
+	return errors.New("hostname not found")
+}


### PR DESCRIPTION
This PR adds a method `provider.DeleteCredentials(context, hostname) error` to remove a Credentials entity from Google Cloud Datastore. This is needed to support deletion in `bmctool` in future, since it uses the Reboot API's `creds` module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/24)
<!-- Reviewable:end -->
