### PR TITLE
Fix DeleteCredentials() and add tests

### DIFF
--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -38,9 +38,13 @@ func (p *FakeProvider) AddCredentials(ctx context.Context, host string,
 }
 
 // DeleteCredentials removes a Credentials from the map.
+// Note: GCD does not return an error if the key does not exist. However, to
+// make this easier to test, FakeProvider.DeleteCredentials will fail in that
+// case.
 func (p *FakeProvider) DeleteCredentials(ctx context.Context, host string) error {
 	if _, ok := p.creds[host]; ok {
 		delete(p.creds, host)
+		return nil
 	}
 	return errors.New("hostname not found")
 }

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -62,3 +62,31 @@ func TestNewProvider(t *testing.T) {
 		t.Errorf("NewProvider() returned nil.")
 	}
 }
+
+func TestFakeProvider_DeleteCredentials(t *testing.T) {
+	fakeDrac := &creds.Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider := &FakeProvider{
+		creds: map[string]*creds.Credentials{
+			"test": fakeDrac,
+		},
+	}
+
+	err := provider.DeleteCredentials(context.Background(), "test")
+	if err != nil {
+		t.Errorf("DeleteCredentials() returned an error: %v", err)
+	}
+
+	// This should fail the second time as the entity has been removed.
+	err = provider.DeleteCredentials(context.Background(), "test")
+	if err == nil {
+		t.Errorf("DeleteCredentials() - expected err, got nil.")
+	}
+
+}


### PR DESCRIPTION
This PR fixes the behavior of `FakeProvider.DeleteCredentials()`. Please note that to make testing easier `FakeProvider` will return an error if the hostname is not a key in its map. This differs from GCD's behavior of returning `nil` if the key we're trying to delete does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/25)
<!-- Reviewable:end -->
