### PR TITLE
Change creds.Provider to allow for connection reuse

### DIFF
--- a/creds/connector.go
+++ b/creds/connector.go
@@ -17,12 +17,16 @@ type client interface {
 	Close() error
 }
 
-type connector interface {
+// Connector is an interface to abstract a new Client creation.
+type Connector interface {
 	NewClient(context.Context, string, ...option.ClientOption) (client, error)
 }
 
-type datastoreConnector struct{}
+// DatastoreConnector is the default implementation of a Connector. It allows to
+// create a new datastore Client.
+type DatastoreConnector struct{}
 
-func (d *datastoreConnector) NewClient(ctx context.Context, projectID string, opts ...option.ClientOption) (client, error) {
+// NewClient returns a datastore Client with the provided configuration.
+func (d *DatastoreConnector) NewClient(ctx context.Context, projectID string, opts ...option.ClientOption) (client, error) {
 	return datastore.NewClient(ctx, projectID, opts...)
 }

--- a/creds/connector_test.go
+++ b/creds/connector_test.go
@@ -6,6 +6,6 @@ import (
 )
 
 func Test_datastoreConnector_NewClient(t *testing.T) {
-	connector := datastoreConnector{}
+	connector := DatastoreConnector{}
 	connector.NewClient(context.Background(), "testproject")
 }

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -58,7 +58,7 @@ type datastoreProvider struct {
 
 // NewProvider creates a new Provider for the given projectID and namespace.
 // The underlying client is initialized via the provided connector.
-func NewProvider(connector connector, projectID, namespace string) (Provider, error) {
+func NewProvider(connector Connector, projectID, namespace string) (Provider, error) {
 	client, err := connector.NewClient(context.Background(), projectID)
 	if err != nil {
 		log.WithError(err).Error("cannot create Datastore client")

--- a/main.go
+++ b/main.go
@@ -90,7 +90,10 @@ func main() {
 
 	// Initialize configuration, credentials provider and connector.
 	rebootConfig := createRebootConfig()
-	credentials := creds.NewProvider(*projectID, *namespace)
+	credentials, err := creds.NewProvider(&creds.DatastoreConnector{},
+		*projectID, *namespace)
+	rtx.Must(err, "Cannot initialize Datastore connection")
+
 	connector := connector.NewConnector()
 
 	var (


### PR DESCRIPTION
This PR changes `creds.Provider` so that a single Datastore client is re-used, as opposed to every method opening/closing its own connection, which does not scale well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/27)
<!-- Reviewable:end -->
