### PR TITLE
Add Close() method to Provider and FakeProvider

### DIFF
--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -48,3 +48,8 @@ func (p *FakeProvider) DeleteCredentials(ctx context.Context, host string) error
 	}
 	return errors.New("hostname not found")
 }
+
+// Close does not do anything as there is no actual connection.
+func (p *FakeProvider) Close() error {
+	return nil
+}

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -90,3 +90,8 @@ func TestFakeProvider_DeleteCredentials(t *testing.T) {
 	}
 
 }
+
+func TestFakeProvider_Close(t *testing.T) {
+	provider := &FakeProvider{}
+	provider.Close()
+}

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -46,6 +46,9 @@ type Provider interface {
 	// DeleteCredentials removes existing Credentials entities from this
 	// provider.
 	DeleteCredentials(context.Context, string) error
+
+	// Close closes the underlying Client connection.
+	Close() error
 }
 
 // datastoreProvider is a Provider based on Google Cloud Datastore.


### PR DESCRIPTION
This PR adds `Close()` to the `Provider` interface and to `FakeProvider`.
I missed this in my previous PR since `main.go` directly uses the `DatastoreProvider` implementation - which makes it harder to test, and is another issue for me to tackle in future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/28)
<!-- Reviewable:end -->
