### PR TITLE
Add ExecDRACShell implementing workaround to run commands on DRACs

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -139,6 +139,9 @@ func (c *sshConnection) exec(cmd string) (string, error) {
 // correctly after a command's execution - thus, session.Wait() hangs
 // indefinitely. However, the exit code is sent after the session is closed,
 // which can be forced 1. with stdin.Close() 2. by writing "exit" on stdin.
+//
+// To know if the command execution has succeeded, the client of this API
+// *must* check stdout/stderr.
 func (c *sshConnection) ExecDRACShell(cmd string) (string, error) {
 	session, err := c.client.NewSession()
 	if err != nil {
@@ -176,7 +179,8 @@ func (c *sshConnection) ExecDRACShell(cmd string) (string, error) {
 		return "", err
 	}
 
-	log.Println("Waiting...")
+	// The error returned by Wait() will always be 254, so it does not make
+	// sense to check it here.
 	session.Wait()
 
 	readers := io.MultiReader(stdout, stderr)

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -179,8 +179,8 @@ func (c *sshConnection) ExecDRACShell(cmd string) (string, error) {
 		return "", err
 	}
 
-	// The error returned by Wait() will always be 254, so it does not make
-	// sense to check it here.
+	// Wait() will always return an error here, even if the main command's
+	// execution has been successful, so we ignore it.
 	session.Wait()
 
 	readers := io.MultiReader(stdout, stderr)

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -105,6 +106,7 @@ func NewConnector() Connector {
 
 // Connection is any kind of connection over which some commands can be run.
 type Connection interface {
+	ExecDRACShell(string) (string, error)
 	Reboot() (string, error)
 	Close() error
 }
@@ -129,6 +131,61 @@ func (c *sshConnection) exec(cmd string) (string, error) {
 	}
 
 	return string(output), err
+}
+
+// ExecDRACShell runs a command in shell mode on a DRAC's SSH server.
+//
+// Due to $reasons (a bug?) the server does not seem to send exit codes
+// correctly after a command's execution - thus, session.Wait() hangs
+// indefinitely. However, the exit code is sent after the session is closed,
+// which can be forced 1. with stdin.Close() 2. by writing "exit" on stdin.
+func (c *sshConnection) ExecDRACShell(cmd string) (string, error) {
+	session, err := c.client.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	stdin, err := session.StdinPipe()
+	if err != nil {
+		return "", err
+	}
+
+	stdout, err := session.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+
+	stderr, err := session.StderrPipe()
+	if err != nil {
+		return "", err
+	}
+
+	err = session.Shell()
+	if err != nil {
+		return "", err
+	}
+
+	_, err = fmt.Fprintf(stdin, "%s\n", cmd)
+	if err != nil {
+		return "", err
+	}
+
+	_, err = fmt.Fprintf(stdin, "exit\n")
+	if err != nil {
+		return "", err
+	}
+
+	log.Println("Waiting...")
+	session.Wait()
+
+	readers := io.MultiReader(stdout, stderr)
+	out, err := ioutil.ReadAll(readers)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
 }
 
 // Reboot reboots the node via this Connection. The method to perform the

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -56,6 +57,26 @@ func (session *mockSession) CombinedOutput(cmd string) ([]byte, error) {
 }
 
 func (session *mockSession) Close() error {
+	return nil
+}
+
+func (session *mockSession) Shell() error {
+	return nil
+}
+
+func (session *mockSession) StdinPipe() (io.WriteCloser, error) {
+	return nil, nil
+}
+
+func (session *mockSession) StdoutPipe() (io.Reader, error) {
+	return nil, nil
+}
+
+func (session *mockSession) StderrPipe() (io.Reader, error) {
+	return nil, nil
+}
+
+func (session *mockSession) Wait() error {
 	return nil
 }
 

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -1,9 +1,11 @@
 package connector
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -64,16 +66,24 @@ func (session *mockSession) Shell() error {
 	return nil
 }
 
+type mockStdin struct {
+	bytes.Buffer
+}
+
+func (stdin *mockStdin) Close() error {
+	return nil
+}
+
 func (session *mockSession) StdinPipe() (io.WriteCloser, error) {
-	return nil, nil
+	return &mockStdin{}, nil
 }
 
 func (session *mockSession) StdoutPipe() (io.Reader, error) {
-	return nil, nil
+	return strings.NewReader("test output"), nil
 }
 
 func (session *mockSession) StderrPipe() (io.Reader, error) {
-	return nil, nil
+	return strings.NewReader("error"), nil
 }
 
 func (session *mockSession) Wait() error {
@@ -242,5 +252,31 @@ func Test_sshConnection_Close(t *testing.T) {
 	err = conn.Close()
 	if err == nil {
 		t.Errorf("Close() unexpected error: %v", err)
+	}
+	mc.mustFail = false
+}
+
+func Test_sshConnection_ExecDRACShell(t *testing.T) {
+	connector := &sshConnector{
+		dialer: md,
+	}
+
+	config := &ConnectionConfig{
+		Hostname:       "testhost",
+		Port:           22,
+		Username:       "testuser",
+		Password:       "testpass",
+		PrivateKeyFile: "",
+		ConnType:       BMCConnection,
+	}
+
+	bmcConn, err := connector.NewConnection(config)
+	if err != nil {
+		t.Errorf("NewConnection() - unexpected error: %v", err)
+	}
+
+	_, err = bmcConn.ExecDRACShell("exit")
+	if err != nil {
+		t.Errorf("ExecDRACShell() returned error: %v", err)
 	}
 }

--- a/connector/dialer.go
+++ b/connector/dialer.go
@@ -1,6 +1,10 @@
 package connector
 
-import "golang.org/x/crypto/ssh"
+import (
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
 
 // dialer is an interface to allow mocking of ssh.Dial in unit tests.
 type dialer interface {
@@ -16,6 +20,11 @@ type client interface {
 type session interface {
 	CombinedOutput(cmd string) ([]byte, error)
 	Close() error
+	Shell() error
+	StdinPipe() (io.WriteCloser, error)
+	StdoutPipe() (io.Reader, error)
+	StderrPipe() (io.Reader, error)
+	Wait() error
 }
 
 type sshDialer struct{}

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -32,6 +32,10 @@ func (connector *mockConnector) NewConnection(*connector.ConnectionConfig) (conn
 	return &mockConnection{}, nil
 }
 
+func (connection *mockConnection) ExecDRACShell(string) (string, error) {
+	return "Not implemented", nil
+}
+
 func (connection *mockConnection) Reboot() (string, error) {
 	return "Not implemented", nil
 }

--- a/reboot/handler_test.go
+++ b/reboot/handler_test.go
@@ -33,6 +33,10 @@ func (connector *mockConnector) NewConnection(*connector.ConnectionConfig) (conn
 	}, nil
 }
 
+func (connection *mockConnection) ExecDRACShell(string) (string, error) {
+	return "Not implemented", nil
+}
+
 func (connection *mockConnection) Reboot() (string, error) {
 	if connection.mustFail {
 		return "", errors.New("method Reboot() failed")


### PR DESCRIPTION
This PR adds `connection.ExecDRACShell` which runs a command in SSH's "shell" mode and work around DRAC's limitations. 

On DRAC's SSH server, the exit codes of subprocesses are not returned to the client. I'm not 100% sure whether this is a bug, an incomplete implementation of the SSH spec, or a mistake on my part.

The lack of exit code makes `session.Wait()` hang indefinitely while waiting for the command execution to finish. To work around it, the session is manually closed by sending `exit\n`, so that `session.Wait()` can return.

The error returned by `Wait()` is not checked as it does not mean much - it will always be 254. To know if the execution has succeeded, we need to inspect stdout/stderr.

Yes, it's ugly. :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/29)
<!-- Reviewable:end -->
