### PR TITLE
Implement provider.ListCredentials()

### DIFF
--- a/creds/credstest/provider.go
+++ b/creds/credstest/provider.go
@@ -20,6 +20,17 @@ func NewProvider() *FakeProvider {
 	}
 }
 
+// ListCredentials returns a slice with all the values in the creds map.
+func (p *FakeProvider) ListCredentials(ctx context.Context) ([]*creds.Credentials, error) {
+	v := make([]*creds.Credentials, 0, len(p.creds))
+
+	for _, value := range p.creds {
+		v = append(v, value)
+	}
+
+	return v, nil
+}
+
 // FindCredentials returns a Credentials from the creds map or an error.
 func (p *FakeProvider) FindCredentials(ctx context.Context,
 	host string) (*creds.Credentials, error) {

--- a/creds/credstest/provider_test.go
+++ b/creds/credstest/provider_test.go
@@ -2,6 +2,7 @@ package credstest
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/m-lab/reboot-service/creds"
@@ -28,6 +29,31 @@ func TestFakeProvider_AddCredentials(t *testing.T) {
 	}
 }
 
+func TestFakeProvider_ListCredentials(t *testing.T) {
+	fakeDrac := &creds.Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+
+	provider := &FakeProvider{
+		creds: map[string]*creds.Credentials{
+			"test": fakeDrac,
+		},
+	}
+
+	// Retrieve previously added Credentials from the FakeProvider's map.
+	creds, err := provider.ListCredentials(context.Background())
+	if err != nil {
+		t.Errorf("ListCredentials() returned an error")
+	}
+	fmt.Println(creds[0])
+	if len(creds) != 1 || *creds[0] != *fakeDrac {
+		t.Errorf("ListCredentials() didn't return the expected Credentials.")
+	}
+}
 func TestFakeProvider_FindCredentials(t *testing.T) {
 	fakeDrac := &creds.Credentials{
 		Hostname: "host",

--- a/creds/provider.go
+++ b/creds/provider.go
@@ -38,6 +38,11 @@ func (c *Credentials) String() string {
 
 // Provider is a Credentials provider.
 type Provider interface {
+
+	// ListCredentials lists all the existing Credentials on this Provider.
+	ListCredentials(context.Context) ([]*Credentials, error)
+
+	// FindCredentials gets an existing Credentials from this Provider.
 	FindCredentials(context.Context, string) (*Credentials, error)
 
 	// AddCredentials creates a new Credentials entity on this Provider.
@@ -73,6 +78,20 @@ func NewProvider(connector Connector, projectID, namespace string) (Provider, er
 		namespace: namespace,
 		client:    client,
 	}, nil
+}
+
+func (d *datastoreProvider) ListCredentials(ctx context.Context) ([]*Credentials, error) {
+	log.Debugf("Retrieving all credentials from namespace %v", d.namespace)
+
+	query := datastore.NewQuery(kind).Namespace(d.namespace)
+	var creds []*Credentials
+	_, err := d.client.GetAll(ctx, query, &creds)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return creds, nil
 }
 
 func (d *datastoreProvider) FindCredentials(ctx context.Context, host string) (*Credentials, error) {

--- a/creds/provider_test.go
+++ b/creds/provider_test.go
@@ -89,6 +89,48 @@ func TestNewProvider(t *testing.T) {
 	}
 }
 
+func TestListCredentials(t *testing.T) {
+	// Create a mockClient returning fake Credentials.
+	fakeDrac := &Credentials{
+		Hostname: "host",
+		Username: "user",
+		Password: "pass",
+		Model:    "model",
+		Address:  "address",
+	}
+	mc := &mockClient{
+		Creds: []*Credentials{
+			fakeDrac,
+		},
+	}
+	provider := &datastoreProvider{
+		namespace: "ns",
+		projectID: "projectID",
+		client:    mc,
+	}
+
+	// ListCredentials() should return the known Credentials.
+	creds, err := provider.ListCredentials(context.Background())
+	if err != nil {
+		t.Errorf("ListCredentials() unexpected error")
+	}
+	if len(creds) != 1 {
+		t.Errorf("ListCredentials() returned a slice of the wrong size.")
+	}
+
+	if *creds[0] != *fakeDrac {
+		t.Errorf("ListCredentials() didn't return the expected Credentials.")
+	}
+
+	// ListCredentials should fail if client.GetAll fails.
+	mc.mustFail = true
+	creds, err = provider.ListCredentials(context.Background())
+	if err == nil {
+		t.Errorf("ListCredentials() didn't return an error.")
+	}
+	mc.mustFail = false
+
+}
 func TestFindCredentials(t *testing.T) {
 	// Create a mockClient returning fake Credentials.
 	fakeDrac := &Credentials{


### PR DESCRIPTION
This PR adds the `ListCredentials()` method to `provider` so that all the Credentials can be fetched at once. This allows to list them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/30)
<!-- Reviewable:end -->
