### PR TITLE
Implement caching on the /v1/e2e endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CoreOS hosts is granted through a private SSH key.
 
 ## Rebooting nodes with the Reboot API
 
-The API provides a single endpoint, `/v1/reboot`, which allows to reboot a node with two different methods.
+The API provides a reboot endpoint, `/v1/reboot`, which allows to reboot a node with two different methods.
 
 ### POST /v1/reboot
 
@@ -31,6 +31,44 @@ curl -X POST https://<reboot-api-url>/v1/reboot?host=mlab1.lga0t
 
 ```bash
 curl -X POST https://<reboot-api-url>/v1/reboot?host=mlab1.lga0t&method=host
+```
+
+## End-to-end testing 
+
+The `/v1/e2e` endpoint allows to run an e2e test on a specific BMC.
+
+This endpoint returns a valid Prometheus metric representing the status of the BMC:
+
+```reboot_e2e_result{status="<status>",target="<hostname>"} 1```
+
+Possible statuses are:
+
+Status         | Description
+- | -
+ok | Connection to this BMC was successful
+credentials_not_found | Credentials to access this BMC are not available in the Credentials store
+connection_failed | Connection to this BMC failed
+
+Results are cached by default. You can configure the cache capacity and TTL with `-e2e.cache-capacity` and `-e2e.cache-ttl`.
+
+### GET /v1/e2e
+
+Parameter         | Description
+------------------| ----------------
+`target`          | hostname of the BMC to check
+
+
+#### Examples
+
+```bash
+curl https://<reboot-api-url>/v1/e2e?target=mlab1d.lga0t.measurement-lab.org
+```
+
+*Output*:
+```
+# HELP reboot_e2e_result E2E test result for this target
+# TYPE reboot_e2e_result gauge
+reboot_e2e_result{status="ok",target="mlab1d.lga0t.measurement-lab.org"} 1
 ```
 
 ## Running the Reboot API

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This endpoint returns a valid Prometheus metric representing the status of the B
 
 Possible statuses are:
 
-Status         | Description
-- | -
+Status            | Description
+------------------| ----------------
 ok | Connection to this BMC was successful
 credentials_not_found | Credentials to access this BMC are not available in the Credentials store
 connection_failed | Connection to this BMC failed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ curl -X POST https://<reboot-api-url>/v1/reboot?host=mlab1.lga0t&method=host
 
 The `/v1/e2e` endpoint allows to run an e2e test on a specific BMC.
 
+Results are cached by default. You can configure the cache capacity and TTL with `-e2e.cache-capacity` and `-e2e.cache-ttl`.
+
+### GET /v1/e2e
+
+Parameter         | Description
+------------------| ----------------
+`target`          | hostname of the BMC to check
+
 This endpoint returns a valid Prometheus metric representing the status of the BMC:
 
 ```reboot_e2e_result{status="<status>",target="<hostname>"} 1```
@@ -48,14 +56,6 @@ Status         | Description
 ok | Connection to this BMC was successful
 credentials_not_found | Credentials to access this BMC are not available in the Credentials store
 connection_failed | Connection to this BMC failed
-
-Results are cached by default. You can configure the cache capacity and TTL with `-e2e.cache-capacity` and `-e2e.cache-ttl`.
-
-### GET /v1/e2e
-
-Parameter         | Description
-------------------| ----------------
-`target`          | hostname of the BMC to check
 
 
 #### Examples

--- a/main.go
+++ b/main.go
@@ -48,9 +48,9 @@ var (
 		"Folder where to cache TLS certificates")
 
 	e2eCacheCapacity = flag.Int("e2e.cache-capacity", defaultCacheCapacity,
-		"Maximum cached responses for the e2e endpoint")
-	e2eCacheTTL = flag.Int("e2e.cache-ttl", defaultCacheTTL,
-		"TTL of cached responses for the e2e endpoint, in minutes")
+		"Maximum # of cached responses for the e2e endpoint")
+	e2eCacheTTL = flag.Duration("e2e.cache-ttl", defaultCacheTTL,
+		"TTL of cached responses for the e2e endpoint")
 
 	// Context for the whole program.
 	ctx, cancel = context.WithCancel(context.Background())
@@ -70,7 +70,7 @@ const (
 	// of BMCs on the platform, plus some significant headroom for future
 	// expansion.
 	defaultCacheCapacity = 2000
-	defaultCacheTTL      = 60
+	defaultCacheTTL      = 60 * time.Minute
 )
 
 func init() {
@@ -128,7 +128,7 @@ func main() {
 
 	cacheClient, err := cache.NewClient(
 		cache.ClientWithAdapter(memcache),
-		cache.ClientWithTTL(time.Duration(*e2eCacheTTL)*time.Minute),
+		cache.ClientWithTTL(*e2eCacheTTL),
 	)
 	rtx.Must(err, "Cannot initialize in-memory cache client.")
 


### PR DESCRIPTION
We have recently discovered that Prometheus' `scrape_interval` [should not be higher than the global `evaluation_interval`](https://github.com/m-lab/prometheus-support/issues/630), which in our case means that the `/e2e` endpoint should be called every minute. A connection to every BMC on the M-Lab platform every minute seems too much and floods the lifecycle controller's log.

This PR adds a configurable cache in front of the `/v1/e2e` endpoint so that we aren't actually connecting to the BMC every time. The default TTL for a response is 1 hour and the default cache capacity is 2000 entities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/32)
<!-- Reviewable:end -->
