### PR TITLE
Add support for v2 hostnames

### DIFF
--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -5,18 +5,15 @@ package e2e
 import (
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/apex/log"
+	"github.com/m-lab/go/host"
 	"github.com/m-lab/reboot-service/connector"
 	"github.com/m-lab/reboot-service/creds"
 )
-
-var bmcV1Regex = regexp.MustCompile(`^(mlab[1-4]d)\.([a-z]{3}[0-9tc]{2}).*`)
-var bmcV2Regex = regexp.MustCompile(`^(mlab[1-4]d)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)$`)
 
 // Handler is the HTTP handler for /e2e
 type Handler struct {
@@ -53,7 +50,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Parses the target parameter. If a valid BMC hostname cannot be extracted
 	// we are reasonably sure this is not a valid M-Lab node's BMC.
-	bmcHost, err := parseBMCHostname(target)
+	bmcName, err := host.Parse(target)
 	if err != nil {
 		errStr := fmt.Sprintf(target)
 		w.WriteHeader(http.StatusBadRequest)
@@ -69,26 +66,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	registry := prometheus.NewRegistry()
-	collector := newE2ETestCollector(bmcHost, collectorConfig)
+	collector := newE2ETestCollector(bmcName.String(), collectorConfig)
 	registry.MustRegister(collector)
 	promHandler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	promHandler.ServeHTTP(w, r)
-}
-
-// parseBMCHostname matches the provided hostname against a regex and returns
-// a full valid M-Lab BMC hostname, if possible.
-func parseBMCHostname(hostname string) (string, error) {
-	result := bmcV2Regex.FindStringSubmatch(hostname)
-	if len(result) == 5 {
-		return fmt.Sprintf("%s-%s.%s.measurement-lab.org", result[1], result[2], result[3]), nil
-	}
-
-	result = bmcV1Regex.FindStringSubmatch(hostname)
-	if len(result) == 3 {
-		return fmt.Sprintf("%s.%s.measurement-lab.org", result[1], result[2]), nil
-	}
-
-	return "",
-		fmt.Errorf("The specified hostname is not a valid BMC hostname: %s", hostname)
-
 }

--- a/e2e/handler.go
+++ b/e2e/handler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/m-lab/reboot-service/creds"
 )
 
-var bmcHostRegex = regexp.MustCompile("(mlab[1-4]d)\\.([a-zA-Z]{3}[0-9t]{2}).*")
 var bmcV1Regex = regexp.MustCompile(`^(mlab[1-4]d)\.([a-z]{3}[0-9tc]{2}).*`)
 var bmcV2Regex = regexp.MustCompile(`^(mlab[1-4]d)-([a-z]{3}[0-9tc]{2})\.(.*?)\.(measurement-lab.org)$`)
 

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -31,21 +31,21 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		connectorMustFail bool
 	}{
 		{
-			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t", nil),
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t.measurement-lab.org", nil),
 			status: http.StatusOK,
 			body: expMetadata + `reboot_e2e_result{status="` + statusOK +
 				`",target="mlab1d.abc0t.measurement-lab.org"} 1
 `,
 		},
 		{
-			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.abc0t", nil),
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.abc0t.measurement-lab.org", nil),
 			status: http.StatusOK,
 			body: expMetadata + `reboot_e2e_result{status="` + statusCredsNotFound +
 				`",target="mlab2d.abc0t.measurement-lab.org"} 0
 `,
 		},
 		{
-			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t", nil),
+			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t.measurement-lab.org", nil),
 			status:            http.StatusOK,
 			connectorMustFail: true,
 			body: expMetadata + `reboot_e2e_result{status="` + statusConnectionFailed +
@@ -53,7 +53,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 `,
 		},
 		{
-			req:    httptest.NewRequest("POST", "/v1/e2e?target=mlab1d.abc0t", nil),
+			req:    httptest.NewRequest("POST", "/v1/e2e?target=mlab1d.abc0t.measurement-lab.org", nil),
 			status: http.StatusMethodNotAllowed,
 		},
 		{
@@ -72,7 +72,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	provider := credstest.NewProvider()
 	provider.AddCredentials(context.Background(),
 		"mlab1d.abc0t.measurement-lab.org", &creds.Credentials{
-			Hostname: "mlab1.abc0t",
+			Hostname: "mlab1.abc0t.measurement-lab.org",
 			Username: "testuser",
 			Password: "testpass",
 			Model:    "drac",
@@ -114,51 +114,4 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		}
 	}
 
-}
-
-func Test_parseBMCHostname(t *testing.T) {
-	tests := []struct {
-		name     string
-		hostname string
-		want     string
-		wantErr  bool
-	}{
-		{
-			name:     "ok-full-hostname",
-			hostname: "mlab1d.abc0t.measurement-lab.org",
-			want:     "mlab1d.abc0t.measurement-lab.org",
-		},
-		{
-			name:     "ok-shorthand-hostname",
-			hostname: "mlab1d.abc0t",
-			want:     "mlab1d.abc0t.measurement-lab.org",
-		},
-		{
-			name:     "ok-v2-hostname",
-			hostname: "mlab1d-abc0t.test.measurement-lab.org",
-			want:     "mlab1d-abc0t.test.measurement-lab.org",
-		},
-		{
-			name:     "failure-wrong-node-name",
-			hostname: "mlab1.abc0t",
-			wantErr:  true,
-		},
-		{
-			name:     "failure-wrong-site-name",
-			hostname: "mlab1d.abc0",
-			wantErr:  true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseBMCHostname(tt.hostname)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseBMCHostname() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("parseBMCHostname() = %v, want %v", got, tt.want)
-			}
-		})
-	}
 }

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -134,6 +134,11 @@ func Test_parseBMCHostname(t *testing.T) {
 			want:     "mlab1d.abc0t.measurement-lab.org",
 		},
 		{
+			name:     "ok-v2-hostname",
+			hostname: "mlab1d-abc0t.test.measurement-lab.org",
+			want:     "mlab1d-abc0t.test.measurement-lab.org",
+		},
+		{
 			name:     "failure-wrong-node-name",
 			hostname: "mlab1.abc0t",
 			wantErr:  true,

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -31,10 +31,10 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		connectorMustFail bool
 	}{
 		{
-			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t.measurement-lab.org", nil),
+			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status: http.StatusOK,
 			body: expMetadata + `reboot_e2e_result{status="` + statusOK +
-				`",target="mlab1d.abc0t.measurement-lab.org"} 1
+				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 1
 `,
 		},
 		{
@@ -45,11 +45,11 @@ func TestHandler_ServeHTTP(t *testing.T) {
 `,
 		},
 		{
-			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d.abc0t.measurement-lab.org", nil),
+			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status:            http.StatusOK,
 			connectorMustFail: true,
 			body: expMetadata + `reboot_e2e_result{status="` + statusConnectionFailed +
-				`",target="mlab1d.abc0t.measurement-lab.org"} 0
+				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 0
 `,
 		},
 		{
@@ -71,8 +71,8 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	// Create a FakeProvider and populate it with fake Credentials.
 	provider := credstest.NewProvider()
 	provider.AddCredentials(context.Background(),
-		"mlab1d.abc0t.measurement-lab.org", &creds.Credentials{
-			Hostname: "mlab1.abc0t.measurement-lab.org",
+		"mlab1d-abc0t.mlab-sandbox.measurement-lab.org", &creds.Credentials{
+			Hostname: "mlab1d-abc0t.mlab-sandbox.measurement-lab.org",
 			Username: "testuser",
 			Password: "testpass",
 			Model:    "drac",


### PR DESCRIPTION
`/v1/e2e` did not previously know about v2 hostnames, now it does. Both v1 and v2 hostname formats are accepted.

This closes https://github.com/m-lab/reboot-service/issues/33.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/34)
<!-- Reviewable:end -->
