### PR TITLE
Make sure BMC hostnames always end in 'd' before querying datastore.

### DIFF
--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) rebootHost(ctx context.Context, node host.Name) (string, error
 }
 
 func (h *Handler) rebootBMC(ctx context.Context, node host.Name) (string, error) {
-	// BMC hostnames are always suffixed with 'd'.
+	// BMC machine names are always suffixed with 'd'.
 	if !strings.HasSuffix(node.Site, "d") {
 		node.Site = node.Site + "d"
 	}

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -112,8 +112,8 @@ func (h *Handler) rebootHost(ctx context.Context, node host.Name) (string, error
 
 func (h *Handler) rebootBMC(ctx context.Context, node host.Name) (string, error) {
 	// BMC machine names are always suffixed with 'd'.
-	if !strings.HasSuffix(node.Site, "d") {
-		node.Site = node.Site + "d"
+	if !strings.HasSuffix(node.Machine, "d") {
+		node.Machine = node.Machine + "d"
 	}
 
 	// Retrieve credentials from the credentials provider.

--- a/reboot/handler.go
+++ b/reboot/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/apex/log"
@@ -110,6 +111,11 @@ func (h *Handler) rebootHost(ctx context.Context, node host.Name) (string, error
 }
 
 func (h *Handler) rebootBMC(ctx context.Context, node host.Name) (string, error) {
+	// BMC hostnames are always suffixed with 'd'.
+	if !strings.HasSuffix(node.Site, "d") {
+		node.Site = node.Site + "d"
+	}
+
 	// Retrieve credentials from the credentials provider.
 	creds, err := h.credsProvider.FindCredentials(ctx, node.String())
 	if err != nil {


### PR DESCRIPTION
This fixes a quite critical bug: if the reboot method is unspecified (and thus "bmc") the machine name should always end in 'd' (e.g. `mlab1d-xyz01.mlab-oti.measurement-lab.org`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/37)
<!-- Reviewable:end -->
