### PR TITLE
Change the default BMC port to 22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+- "1.14.3"
+
 before_script:
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls

--- a/main.go
+++ b/main.go
@@ -62,7 +62,7 @@ const (
 	defaultProjID     = "mlab-sandbox"
 	defaultNamespace  = "reboot-api"
 	defaultSSHPort    = 22
-	defaultBMCPort    = 806
+	defaultBMCPort    = 22
 	defaultRebootUser = "reboot-api"
 	defaultCertsDir   = "/var/tls/"
 


### PR DESCRIPTION
This PR changes the default DRAC port used by reboot-service to 22. This change is related to automating the DRAC configuration during stage1/2 (https://github.com/m-lab/epoxy/issues/94)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/38)
<!-- Reviewable:end -->
