### PR TITLE
Improves Prometheus metric reboot_e2e_result. 

### DIFF
--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	statusOK               = "ok"
 	reasonSuccess          = "success"
 	reasonCredsNotFound    = "credentials_not_found"
 	reasonConnectionFailed = "connection_failed"
@@ -37,8 +36,8 @@ func newE2ETestCollector(target string, config *collectorConfig) *e2eTestCollect
 	return &e2eTestCollector{
 		target: target,
 		config: config,
-		resultMetric: prometheus.NewDesc("reboot_e2e_result",
-			"E2E test result for this target", []string{"target", "status", "reason"},
+		resultMetric: prometheus.NewDesc("reboot_e2e_success",
+			"E2E test result for this target", []string{"target", "reason"},
 			nil),
 	}
 }
@@ -53,7 +52,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		log.Errorf("Error while getting credentials for %s: %v", c.target, err)
 		ch <- prometheus.MustNewConstMetric(c.resultMetric,
-			prometheus.GaugeValue, 0, c.target, statusOK, reasonCredsNotFound)
+			prometheus.GaugeValue, 0, c.target, reasonCredsNotFound)
 		return
 	}
 
@@ -71,7 +70,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 		// TODO: here we should be able to distinguish different errors.
 		log.Errorf("Error while creating connection to %s: %v", c.target, err)
 		ch <- prometheus.MustNewConstMetric(c.resultMetric,
-			prometheus.GaugeValue, 0, c.target, statusOK, reasonConnectionFailed)
+			prometheus.GaugeValue, 0, c.target, reasonConnectionFailed)
 		return
 	}
 
@@ -79,7 +78,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 	conn.Close()
 
 	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue,
-		1, c.target, statusOK, reasonSuccess)
+		1, c.target, reasonSuccess)
 }
 
 func (c *e2eTestCollector) getCredentials(hostname string) (*creds.Credentials, error) {

--- a/e2e/collector.go
+++ b/e2e/collector.go
@@ -13,8 +13,9 @@ import (
 
 const (
 	statusOK               = "ok"
-	statusCredsNotFound    = "credentials_not_found"
-	statusConnectionFailed = "connection_failed"
+	reasonSuccess          = "success"
+	reasonCredsNotFound    = "credentials_not_found"
+	reasonConnectionFailed = "connection_failed"
 
 	// Timeout for the e2e test must be shorter than Prometheus' timeout.
 	connectionTimeout = 45 * time.Second
@@ -37,7 +38,7 @@ func newE2ETestCollector(target string, config *collectorConfig) *e2eTestCollect
 		target: target,
 		config: config,
 		resultMetric: prometheus.NewDesc("reboot_e2e_result",
-			"E2E test result for this target", []string{"target", "status"},
+			"E2E test result for this target", []string{"target", "status", "reason"},
 			nil),
 	}
 }
@@ -52,7 +53,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		log.Errorf("Error while getting credentials for %s: %v", c.target, err)
 		ch <- prometheus.MustNewConstMetric(c.resultMetric,
-			prometheus.GaugeValue, 0, c.target, statusCredsNotFound)
+			prometheus.GaugeValue, 0, c.target, statusOK, reasonCredsNotFound)
 		return
 	}
 
@@ -70,7 +71,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 		// TODO: here we should be able to distinguish different errors.
 		log.Errorf("Error while creating connection to %s: %v", c.target, err)
 		ch <- prometheus.MustNewConstMetric(c.resultMetric,
-			prometheus.GaugeValue, 0, c.target, statusConnectionFailed)
+			prometheus.GaugeValue, 0, c.target, statusOK, reasonConnectionFailed)
 		return
 	}
 
@@ -78,7 +79,7 @@ func (c *e2eTestCollector) Collect(ch chan<- prometheus.Metric) {
 	conn.Close()
 
 	ch <- prometheus.MustNewConstMetric(c.resultMetric, prometheus.GaugeValue,
-		1, c.target, statusOK)
+		1, c.target, statusOK, reasonSuccess)
 }
 
 func (c *e2eTestCollector) getCredentials(hostname string) (*creds.Credentials, error) {

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -74,12 +74,12 @@ func Test_e2eTestCollector_Collect(t *testing.T) {
 	collector := newE2ETestCollector("mlab1d.abc0t.measurement-lab.org", config)
 
 	// Compare actual vs expected output in the "ok" case.
-	expMetadata := `# HELP reboot_e2e_result E2E test result for this target
-# TYPE reboot_e2e_result gauge
+	expMetadata := `# HELP reboot_e2e_success E2E test result for this target
+# TYPE reboot_e2e_success gauge
 
 `
 	expMetric := `
-reboot_e2e_result{reason="` + reasonSuccess + `",status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 1
+reboot_e2e_success{reason="` + reasonSuccess + `",target="mlab1d.abc0t.measurement-lab.org"} 1
 `
 	err := testutil.CollectAndCompare(collector, strings.NewReader(
 		expMetadata+expMetric))
@@ -89,7 +89,7 @@ reboot_e2e_result{reason="` + reasonSuccess + `",status="` + statusOK + `",targe
 
 	// Compare actual vs expected output in the "connection_failed" case.
 	expMetric = `
-reboot_e2e_result{reason="` + reasonConnectionFailed + `",status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 0
+reboot_e2e_success{reason="` + reasonConnectionFailed + `",target="mlab1d.abc0t.measurement-lab.org"} 0
 `
 	connector.mustFail = true
 	collector = newE2ETestCollector("mlab1d.abc0t.measurement-lab.org", config)
@@ -101,7 +101,7 @@ reboot_e2e_result{reason="` + reasonConnectionFailed + `",status="` + statusOK +
 
 	// Compare actual vs expected output in the "credentials_not_found" case.
 	expMetric = `
-reboot_e2e_result{reason="` + reasonCredsNotFound + `",status="` + statusOK + `",target="mlab2d.abc0t.measurement-lab.org"} 0
+reboot_e2e_success{reason="` + reasonCredsNotFound + `",target="mlab2d.abc0t.measurement-lab.org"} 0
 `
 	collector = newE2ETestCollector("mlab2d.abc0t.measurement-lab.org", config)
 	err = testutil.CollectAndCompare(collector, strings.NewReader(

--- a/e2e/collector_test.go
+++ b/e2e/collector_test.go
@@ -79,7 +79,7 @@ func Test_e2eTestCollector_Collect(t *testing.T) {
 
 `
 	expMetric := `
-reboot_e2e_result{status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 1
+reboot_e2e_result{reason="` + reasonSuccess + `",status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 1
 `
 	err := testutil.CollectAndCompare(collector, strings.NewReader(
 		expMetadata+expMetric))
@@ -87,9 +87,9 @@ reboot_e2e_result{status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab
 		t.Errorf("CollectAndCompare() returned err: %v", err)
 	}
 
-	// COmpare actual vs expected output in the "connection_failed" case.
+	// Compare actual vs expected output in the "connection_failed" case.
 	expMetric = `
-reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.abc0t.measurement-lab.org"} 0
+reboot_e2e_result{reason="` + reasonConnectionFailed + `",status="` + statusOK + `",target="mlab1d.abc0t.measurement-lab.org"} 0
 `
 	connector.mustFail = true
 	collector = newE2ETestCollector("mlab1d.abc0t.measurement-lab.org", config)
@@ -101,7 +101,7 @@ reboot_e2e_result{status="` + statusConnectionFailed + `",target="mlab1d.abc0t.m
 
 	// Compare actual vs expected output in the "credentials_not_found" case.
 	expMetric = `
-reboot_e2e_result{status="` + statusCredsNotFound + `",target="mlab2d.abc0t.measurement-lab.org"} 0
+reboot_e2e_result{reason="` + reasonCredsNotFound + `",status="` + statusOK + `",target="mlab2d.abc0t.measurement-lab.org"} 0
 `
 	collector = newE2ETestCollector("mlab2d.abc0t.measurement-lab.org", config)
 	err = testutil.CollectAndCompare(collector, strings.NewReader(

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -21,8 +21,8 @@ func TestNewHandler(t *testing.T) {
 }
 
 func TestHandler_ServeHTTP(t *testing.T) {
-	expMetadata := `# HELP reboot_e2e_result E2E test result for this target
-# TYPE reboot_e2e_result gauge
+	expMetadata := `# HELP reboot_e2e_success E2E test result for this target
+# TYPE reboot_e2e_success gauge
 `
 	tests := []struct {
 		req               *http.Request
@@ -33,23 +33,23 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status: http.StatusOK,
-			body: expMetadata + `reboot_e2e_result{reason="` + reasonSuccess + `",status="` + statusOK +
+			body: expMetadata + `reboot_e2e_success{reason="` + reasonSuccess +
 				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 1
 `,
 		},
 		{
 			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.abc0t.measurement-lab.org", nil),
 			status: http.StatusOK,
-			body: expMetadata + `reboot_e2e_result{reason="` + reasonCredsNotFound +
-				`",status="` + statusOK + `",target="mlab2d.abc0t.measurement-lab.org"} 0
+			body: expMetadata + `reboot_e2e_success{reason="` + reasonCredsNotFound +
+				`",target="mlab2d.abc0t.measurement-lab.org"} 0
 `,
 		},
 		{
 			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status:            http.StatusOK,
 			connectorMustFail: true,
-			body: expMetadata + `reboot_e2e_result{reason="` + reasonConnectionFailed +
-				`",status="` + statusOK + `",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 0
+			body: expMetadata + `reboot_e2e_success{reason="` + reasonConnectionFailed +
+				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 0
 `,
 		},
 		{

--- a/e2e/handler_test.go
+++ b/e2e/handler_test.go
@@ -33,23 +33,23 @@ func TestHandler_ServeHTTP(t *testing.T) {
 		{
 			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status: http.StatusOK,
-			body: expMetadata + `reboot_e2e_result{status="` + statusOK +
+			body: expMetadata + `reboot_e2e_result{reason="` + reasonSuccess + `",status="` + statusOK +
 				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 1
 `,
 		},
 		{
 			req:    httptest.NewRequest("GET", "/v1/e2e?target=mlab2d.abc0t.measurement-lab.org", nil),
 			status: http.StatusOK,
-			body: expMetadata + `reboot_e2e_result{status="` + statusCredsNotFound +
-				`",target="mlab2d.abc0t.measurement-lab.org"} 0
+			body: expMetadata + `reboot_e2e_result{reason="` + reasonCredsNotFound +
+				`",status="` + statusOK + `",target="mlab2d.abc0t.measurement-lab.org"} 0
 `,
 		},
 		{
 			req:               httptest.NewRequest("GET", "/v1/e2e?target=mlab1d-abc0t.mlab-sandbox.measurement-lab.org", nil),
 			status:            http.StatusOK,
 			connectorMustFail: true,
-			body: expMetadata + `reboot_e2e_result{status="` + statusConnectionFailed +
-				`",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 0
+			body: expMetadata + `reboot_e2e_result{reason="` + reasonConnectionFailed +
+				`",status="` + statusOK + `",target="mlab1d-abc0t.mlab-sandbox.measurement-lab.org"} 0
 `,
 		},
 		{
@@ -109,7 +109,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 				t.Errorf("ServeHTTP() - cannot read response: %v", err)
 			}
 			if string(body) != test.body {
-				t.Errorf("ServeHTTP() - unexpected response: %s", string(body))
+				t.Errorf("ServeHTTP() - expected response:\n%s\ngot:\n%s\n", string(body), test.body)
 			}
 		}
 	}


### PR DESCRIPTION
This PR intends to resolve issue #39. With this PR, the metric exported by the reboot-service will always be of this form:

`reboot_e2e_results{reason="<reason>", status="ok", target="<target>"} <status>`

If <status> is `0`, then the e2e failed (read as `status="ok" == 0`), and a [suitable reason](https://github.com/m-lab/reboot-service/blob/master/e2e/collector.go#L16) for the failure will be in the `reason` label. If the e2e test was successful, the value of this metric will be `1` and the `reason` label will have a value of "success".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/reboot-service/42)
<!-- Reviewable:end -->
